### PR TITLE
feat: add gh pages deployment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,48 @@
+name: AsyncAPI documents processing
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Remove git folder
+        run: rm -rf .git
+
+      - name: Generating HTML for AAS document
+        uses: asyncapi/cli@v3.2.0
+        with:
+          template: '@asyncapi/html-template@2.3.14'
+          filepath: specs/asyncapi_spec_v21_aas.yaml
+          output: aas-repository
+
+      - name: Generating HTML for Submodels document
+        uses: asyncapi/cli@v3.2.0
+        with:
+          template: '@asyncapi/html-template@2.3.14'
+          filepath: specs/asyncapi_spec_v21_submodel.yaml
+          output: submodel-repository
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: generate
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
creates a deployment looking like the ones in my fork

https://arnoweiss.github.io/async-aas-helm/submodel-repository/
https://arnoweiss.github.io/async-aas-helm/aas-repository/

will be available at 

https://factory-x-contributions.github.io/async-aas-helm/submodel-repository/
https://factory-x-contributions.github.io/async-aas-helm/aas-repository/

closes #8