### PR TITLE
Secure FA³ST deployment

### DIFF
--- a/charts/faaast-service/templates/secret.yaml
+++ b/charts/faaast-service/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  auth: {{ (htpasswd .Values.faaast_basic_auth.user .Values.faaast_basic_auth.password) | b64enc | quote }}
+kind: Secret
+metadata:
+  name: faaast-basic-auth-secret
+type: Opaque

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -14,6 +14,9 @@ fullnameOverride: faaast-service
 ingress:
   enabled: true
   annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: faaast-basic-auth-secret
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - FA³ST'
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 10m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -29,6 +29,10 @@ ingress:
 #        - path: /
 #          pathType: Prefix
 
+faaast_basic_auth:
+  user: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-user>"
+  password: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-pw>"
+
 config:
   mountPath: "/app/config/config.json"
 


### PR DESCRIPTION
Adds basic authentication to the FA³ST ingress.


Since the value for `nginx.ingress.kubernetes.io/auth-secret` is a reference to a kubernetes secret, we add a secret to the deployment and reference vault secrets from there. Helm will then build the actual auth data with built-in functions htpasswd and b64enc.