### PR TITLE
Fix: FA³ST deployment auth

### DIFF
--- a/charts/faaast-service/templates/secret.yaml
+++ b/charts/faaast-service/templates/secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  auth: {{ (htpasswd .Values.faaast_basic_auth.user .Values.faaast_basic_auth.password) | b64enc | quote }}
+  auth: {{ (htpasswd .Values.basicAuth.user .Values.basicAuth.password) | b64enc | quote }}
 kind: Secret
 metadata:
   name: faaast-basic-auth-secret

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -11,6 +11,10 @@ service:
 
 fullnameOverride: faaast-service
 
+faaast_basic_auth:
+  user: ""
+  password: ""
+
 ingress:
   enabled: true
   annotations:
@@ -28,10 +32,6 @@ ingress:
 #      paths:
 #        - path: /
 #          pathType: Prefix
-
-faaast_basic_auth:
-  user: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-user>"
-  password: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-pw>"
 
 config:
   mountPath: "/app/config/config.json"

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -11,7 +11,7 @@ service:
 
 fullnameOverride: faaast-service
 
-faaast_basic_auth:
+basicAuth:
   user: ""
   password: ""
 

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -16,7 +16,7 @@ ingress:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: faaast-basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - FA³ST'
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - FAAAST'
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 10m
     cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,10 @@ faaast-service:
           - path: /
             pathType: Prefix
 
+  faaast_basic_auth:
+    user: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-user>"
+    password: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-pw>"
+
 aas-basyx-v2-full:
   mqtt:
     enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ faaast-service:
           - path: /
             pathType: Prefix
 
-  faaast_basic_auth:
+  basicAuth:
     user: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-pw>"
 


### PR DESCRIPTION
#12 introduced two faults:

- invalid encoding of nginx ingress basic auth realm: "FA³ST" contains illegal character ³ -> Replaced by FAAAST
- vault path is not resolved in inner values.yaml file -> Moved to outer values.yaml