### PR TITLE
fix: use more suitable secret type

### DIFF
--- a/charts/faaast-service/templates/secret.yaml
+++ b/charts/faaast-service/templates/secret.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
-data:
-  auth: {{ (htpasswd .Values.basicAuth.user .Values.basicAuth.password) | b64enc | quote }}
+stringData:
+  username: {{ .Values.basicAuth.user }}
+  password: {{ .Values.basicAuth.password }}
 kind: Secret
 metadata:
   name: faaast-basic-auth-secret
-type: Opaque
+type: kubernetes.io/basic-auth


### PR DESCRIPTION
Using [this](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret) secret type could fix the authentication issue or at least give us some more information as to where the problem lies.

Advantage of this secret type is that it (somehow) supports `:` (at least when deploying locally), so if the vault path were to not be resolved, we could simply log in with username `<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-user>` and password `<path:factory-x-ci-cd/data/async-aas#faaast-basic-auth-pw>`