### PR TITLE
chore: fail helm-level if substitution failed

### DIFF
--- a/charts/faaast-service/templates/secret.yaml
+++ b/charts/faaast-service/templates/secret.yaml
@@ -1,5 +1,5 @@
-{{- if (regexMatch ".*<.*" .Values.basicAuth.user) -}}
-  {{- fail "Deployment failed: 'basicAuth.user' contains an invalid character '<'" -}}
+{{- if (regexMatch ".*:.*" .Values.basicAuth.user) -}}
+  {{- fail "Deployment failed: 'basicAuth.user' contains an invalid character ':'" -}}
 {{- end -}}
 
 apiVersion: v1

--- a/charts/faaast-service/templates/secret.yaml
+++ b/charts/faaast-service/templates/secret.yaml
@@ -1,3 +1,7 @@
+{{- if (regexMatch ".*<.*" .Values.basicAuth.user) -}}
+  {{- fail "Deployment failed: 'basicAuth.user' contains an invalid character '<'" -}}
+{{- end -}}
+
 apiVersion: v1
 data:
   auth: {{ (htpasswd .Values.basicAuth.user .Values.basicAuth.password) | b64enc | quote }}


### PR DESCRIPTION
adds a check to fail the deployment if there's and invalid char in the username