### PR TITLE
fix: remove factory-x from type property identifiers

### DIFF
--- a/specs/asyncapi_spec_v21_aas.yaml
+++ b/specs/asyncapi_spec_v21_aas.yaml
@@ -82,7 +82,7 @@ components:
             originated in.
           type: string
           examples:
-            - org.factory-x.events.v1.AASValueChanged
+            - io.admin-shell.events.v1.AASValueChanged
         datacontenttype:
           description: Content type of the event data.
           type: string
@@ -146,7 +146,7 @@ components:
             originated in.
           type: string
           examples:
-            - org.factory-x.events.v1.AASElementCreated
+            - io.admin-shell.events.v1.AASElementCreated
         datacontenttype:
           description: Content type of the event data.
           type: string

--- a/specs/asyncapi_spec_v21_submodel.yaml
+++ b/specs/asyncapi_spec_v21_submodel.yaml
@@ -75,7 +75,7 @@ components:
             originated in.
           type: string
           examples:
-            - org.factory-x.events.v1.SubmodelValueChanged
+            - io.admin-shell.events.v1.SubmodelValueChanged
         datacontenttype:
           description: Content type of the event data.
           type: string
@@ -140,7 +140,7 @@ components:
             originated in.
           type: string
           examples:
-            - org.factory-x.events.v1.SubmodelElementCreated
+            - io.admin-shell.events.v1.SubmodelElementCreated
         datacontenttype:
           description: Content type of the event data.
           type: string


### PR DESCRIPTION
to foster reuse, there shouldn't be any specific mentions to factory-x in the spec