### PR TITLE
fix: nginx request entity too large

### DIFF
--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -22,7 +22,6 @@ ingress:
     nginx.ingress.kubernetes.io/auth-secret: faaast-basic-auth-secret
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - FAAAST'
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-body-size: 150m

--- a/values.yaml
+++ b/values.yaml
@@ -216,7 +216,6 @@ aas-basyx-v2-full:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/enable-cors: "true"
         cert-manager.io/cluster-issuer: letsencrypt-prod
-        nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-body-size: 150m


### PR DESCRIPTION
closes #26 

Also increased nginx timeout values to allow uploads from slow clients.