### PR TITLE
feat: update basyx helm chart rbac

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
     version: 0.1.0
     repository: "file://charts/faaast-service"
   - name: aas-basyx-v2-full
-    version: 2.0.0
+    version: 2.0.4
     repository: "https://eclipse-basyx.github.io/charts/"
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/values.yaml
+++ b/values.yaml
@@ -226,7 +226,187 @@ aas-basyx-v2-full:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-
+    rbac:
+      rules: |
+        [
+          {
+            "role": "admin",
+            "action": ["CREATE", "READ", "UPDATE", "DELETE" ],
+            "targetInformation": {
+              "@type": "concept-description",
+              "conceptDescriptionIds": "*"
+            }
+          },
+          {
+            "role": "admin",
+            "action": [ "CREATE", "READ", "UPDATE", "DELETE" ],
+            "targetInformation": {
+              "@type": "aas",
+              "aasIds": "*"
+            }
+          },
+          {
+            "role": "admin",
+            "action": [ "CREATE", "READ", "UPDATE", "DELETE", "EXECUTE" ],
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "*",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "admin",
+            "action": [ "CREATE", "READ", "UPDATE", "DELETE" ],
+            "targetInformation": {
+              "@type": "aas-environment",
+              "aasIds": "*",
+              "submodelIds": "*"
+            }
+          },
+          {
+            "role": "basyx-reader",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "*",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-reader-two",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-sme-reader",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": [
+                "specificSubmodelId",
+                "testSMId1",
+                "testSMId2"
+              ],
+              "submodelElementIdShortPaths": [
+                "testSMEIdShortPath1",
+                "smc2.specificSubmodelElementIdShort",
+                "testSMEIdShortPath2"
+              ]
+            }
+          },
+          {
+            "role": "basyx-sme-reader-two",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "smc2.specificFileSubmodelElementIdShort"
+            }
+          },
+          {
+            "role": "basyx-updater",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "*",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-updater-two",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-sme-updater",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "smc2.specificFileSubmodelElementIdShort"
+            }
+          },
+          {
+            "role": "basyx-sme-updater-two",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "smc2"
+            }
+          },
+          {
+            "role": "basyx-sme-updater-three",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId-2",
+              "submodelElementIdShortPaths": "smc1.specificSubmodelElementIdShort-2"
+            }
+          },
+          {
+            "role": "basyx-file-sme-updater",
+            "action": "UPDATE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId-2",
+              "submodelElementIdShortPaths": "smc2.specificFileSubmodelElementIdShort"
+            }
+          },
+          {
+            "role": "basyx-deleter",
+            "action": "DELETE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "*",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-deleter-two",
+            "action": "DELETE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId-2",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-executor",
+            "action": "EXECUTE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "*",
+              "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-executor-two",
+            "action": "EXECUTE",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId",
+              "submodelElementIdShortPaths": "square"
+            }
+          },
+          {
+            "role": "basyx-file-sme-reader",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "submodel",
+              "submodelIds": "specificSubmodelId-2",
+              "submodelElementIdShortPaths": "smc2.specificFileSubmodelElementIdShort"
+            }
+          }
+        ]
   # Needs specific ingress.
   aas-web-ui:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,8 @@ aas-basyx-v2-full:
         - secretName: chart-example-tls
           hosts:
             - <path:factory-x-ci-cd/data/async-aas#broker-url>
-    apirules: []
+    apirule:
+      - enabled: false
     auth:
       enabled: true
       users:


### PR DESCRIPTION
Updated BaSyx chart to 2.0.4 which allows for custom RBAC rules.

Gave admin the rights to CRUD+Execute on any of the following:

- aas
- aas-environment
- conceptDescription
- submodel

The rest of the RBAC rules are left unchanged.