### PR TITLE
Fix: dependabot yaml syntax

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "helm" # See documentation for possible values
     directories: 
-      - "/charts/*
+      - "/charts/*"
       - "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Current dependabot yaml is missing a closing quotation mark