### PR TITLE
fix: set optional and required properties in spec payload

### DIFF
--- a/specs/asyncapi_spec_v21_aas.yaml
+++ b/specs/asyncapi_spec_v21_aas.yaml
@@ -102,6 +102,16 @@ components:
             - '2024-11-26T10:46:33.2171298+01:00'
         data:
           $ref: '#/components/schemas/valueChangedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
     valueChangedEventData:
       type: object
       properties:
@@ -167,6 +177,16 @@ components:
             - '2024-11-26T10:44:11.9367113+01:00'
         data:
           $ref: '#/components/schemas/elementCreatedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
     elementCreatedEventData:
       type: object
       properties:

--- a/specs/asyncapi_spec_v21_submodel.yaml
+++ b/specs/asyncapi_spec_v21_submodel.yaml
@@ -95,6 +95,16 @@ components:
             - '2024-11-26T10:46:33.2171298+01:00'
         data:
           $ref: '#/components/schemas/valueChangedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
     valueChangedEventData:
       type: object
       properties:
@@ -160,6 +170,16 @@ components:
             - '2024-11-26T10:44:11.9367113+01:00'
         data:
           $ref: '#/components/schemas/elementCreatedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
     elementCreatedEventData:
       type: object
       properties:


### PR DESCRIPTION
As mentioned in the ticket below the data property in the payload should be optional, therefore the two specs have been updated. Data is now optional whereas the other properties in payload are marked as required.
You can also review this in async api: 

closes #14

- AAS: https://studio.asyncapi.com/?share=cf4c4f9c-452f-4bbb-86fc-2f210cd7d5d6
- Submodel: https://studio.asyncapi.com/?share=26ae185b-a830-46e2-8005-f7f9d7d4502a