### PR TITLE
Fix: ci chart test triggers

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '!**/README.md'
+      - '!specs/**'
       - '.github/workflows/lint-test.yaml'
       - 'charts/**'
       - 'Chart.yaml'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,6 +16,7 @@ on:
       - main
     paths:
       - '!**/README.md'
+      - '!specs/**'
       - '.github/workflows/lint-test.yaml'
       - 'charts/**'
       - 'Chart.yaml'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - '!**/README.md'
       - '.github/workflows/lint-test.yaml'
+      - 'charts/**'
+      - 'Chart.yaml'
 
   push:
     branches:
@@ -14,6 +16,8 @@ on:
     paths:
       - '!**/README.md'
       - '.github/workflows/lint-test.yaml'
+      - 'charts/**'
+      - 'Chart.yaml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Added paths that should trigger the chart testing + linting action on GitHub