### PR TITLE
feat: RabbitMQ deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,6 +8,9 @@ dependencies:
   - name: aas-basyx-v2-full
     version: 2.0.4
     repository: "https://eclipse-basyx.github.io/charts/"
+  - name: rabbitmq
+    version: 16.0.11
+    repository: "https://charts.bitnami.com/bitnami"
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 faaast-service:
   messageBus:
-    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443/mqtt"
+    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443"
     user: "<path:factory-x-ci-cd/data/async-aas#broker-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#broker-pw>"
   ingress:
@@ -33,7 +33,65 @@ faaast-service:
 
 aas-basyx-v2-full:
   mqtt:
-    enabled: false
+    enabled: true
+    websockets:
+      enabled: true
+    ingress:
+      enabled: true
+      ingressClassName: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        kubernetes.io/tls-acme: "true"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+        nginx.ingress.kubernetes.io/websocket-services: mqttbroker-websockets-service
+      hosts:
+        - host: <path:factory-x-ci-cd/data/async-aas#broker-url>
+          type: websockets
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: chart-example-tls
+          hosts:
+            - <path:factory-x-ci-cd/data/async-aas#broker-url>
+    apirule:
+      - enabled: false
+    auth:
+      enabled: true
+      users:
+        - username: fx-factory
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
+        - username: fx-publisher
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
+        - username: fx-subscriber
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
+        - username: fx-factory2
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
+        - username: fx-publisher2
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
+        - username: fx-subscriber2
+          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
+          acl:
+            - topic: "#"
+              access: readwrite
 
   keycloak:
     enabled: true
@@ -385,8 +443,8 @@ rabbitmq:
 
   # RabbitMQ / MQTT User
   auth:
-    username: "<path:factory-x-ci-cd/data/async-aas#broker-user>"
-    password: "<path:factory-x-ci-cd/data/async-aas#broker-pw>"
+    username: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-user>"
+    password: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-pw>"
     updatePassword: true
 
   # Enable MQTT + Websockets
@@ -420,7 +478,7 @@ rabbitmq:
     hostname: ""  # only for management interface, "disable"
 
     extraRules:
-      - host: <path:factory-x-ci-cd/data/async-aas#broker-url>
+      - host: <path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-url>
         http:
           paths:
             - path: /mqtt
@@ -433,5 +491,5 @@ rabbitmq:
     # need to use extraTls because the regular "tls" block is only for management interface
     extraTls:
       - hosts:
-        - <path:factory-x-ci-cd/data/async-aas#broker-url>
+        - <path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-url>
         secretName: chart-example-tls  # TODO taken from basyx-mqtt config, does this need a CI variable?

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 faaast-service:
   messageBus:
-    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443"
+    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443/ws"
     user: "<path:factory-x-ci-cd/data/async-aas#broker-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#broker-pw>"
   ingress:
@@ -33,65 +33,7 @@ faaast-service:
 
 aas-basyx-v2-full:
   mqtt:
-    enabled: true
-    websockets:
-      enabled: true
-    ingress:
-      enabled: true
-      ingressClassName: "nginx"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        kubernetes.io/tls-acme: "true"
-        nginx.ingress.kubernetes.io/enable-cors: "true"
-        cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-        nginx.ingress.kubernetes.io/websocket-services: mqttbroker-websockets-service
-      hosts:
-        - host: <path:factory-x-ci-cd/data/async-aas#broker-url>
-          type: websockets
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-      tls:
-        - secretName: chart-example-tls
-          hosts:
-            - <path:factory-x-ci-cd/data/async-aas#broker-url>
-    apirule:
-      - enabled: false
-    auth:
-      enabled: true
-      users:
-        - username: fx-factory
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
-        - username: fx-publisher
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
-        - username: fx-subscriber
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
-        - username: fx-factory2
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
-        - username: fx-publisher2
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
-        - username: fx-subscriber2
-          password: <path:factory-x-ci-cd/data/async-aas#broker-pw-hash>
-          acl:
-            - topic: "#"
-              access: readwrite
+    enabled: false
 
   keycloak:
     enabled: true
@@ -213,6 +155,7 @@ aas-basyx-v2-full:
       mqtt.port=443
       mqtt.username=<path:factory-x-ci-cd/data/async-aas#broker-user>
       mqtt.password=<path:factory-x-ci-cd/data/async-aas#broker-pw>
+      mqtt.ws_path=/ws  # TODO must be implemented in Basyx
       
       basyx.feature.authorization.enabled = true
       basyx.feature.authorization.type = rbac
@@ -417,3 +360,79 @@ aas-basyx-v2-full:
   # Needs specific ingress.
   aas-web-ui:
     enabled: false
+
+rabbitmq:
+  image:
+    debug: false
+
+  extraContainerPorts:
+  - name: websocket-mqtt
+    containerPort: 9001
+
+  # select exposed ports
+  service:
+    portEnabled: false  # AMQP
+    distPortEnabled: false  # Erlang distribution server
+    managerPortEnabled: false  # RabbitMQ Manager
+    epmdPortEnabled: false  # RabbitMQ EPMD Discovery service
+    extraPorts:
+      - name: websocket-mqtt
+        port: 9001
+        targetPort: 9001
+
+  # disable persistence features using PVC
+  persistence:
+    enabled: false
+
+  # RabbitMQ / MQTT User
+  auth:
+    username: "<path:factory-x-ci-cd/data/async-aas#broker-user>"
+    password: "<path:factory-x-ci-cd/data/async-aas#broker-pw>"
+    updatePassword: true
+
+  # Enable MQTT + Websockets
+  extraPlugins: "rabbitmq_mqtt rabbitmq_web_mqtt"
+
+  # Additional RabbitMQ configuration
+  extraConfiguration: |-
+    vm_memory_high_watermark.relative = 0.8
+
+    web_mqtt.tcp.port = 9001
+    web_mqtt.ws_path = /ws
+
+    mqtt.vhost = /
+    mqtt.exchange = amq.topic
+    mqtt.allow_anonymous = false
+
+    #log.default.level = debug
+
+  ingress:
+    enabled: true
+    ingressClassName: "nginx"
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/websocket-services: rabbitmqttbroker-websockets-service
+    
+    hostname: ""  # only for management interface, "disable"
+
+    extraRules:
+      - host: <path:factory-x-ci-cd/data/async-aas#broker-url>
+        http:
+          paths:
+            - path: /ws
+              pathType: ImplementationSpecific
+              backend:
+                service:
+                  name: rabbitmqttbroker-websockets-service  # TODO verify whether this just works or if we need to use "fullnameOverride"
+                  port: 9001
+
+    # need to use extraTls because the regular "tls" block is only for management interface
+    extraTls:
+      - hosts:
+        - <path:factory-x-ci-cd/data/async-aas#broker-url>
+        secretName: chart-example-tls  # TODO taken from basyx-mqtt config, does this need a CI variable?

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 faaast-service:
   messageBus:
-    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443/ws"
+    host: "wss://<path:factory-x-ci-cd/data/async-aas#broker-url>:443/mqtt"
     user: "<path:factory-x-ci-cd/data/async-aas#broker-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#broker-pw>"
   ingress:
@@ -155,7 +155,6 @@ aas-basyx-v2-full:
       mqtt.port=443
       mqtt.username=<path:factory-x-ci-cd/data/async-aas#broker-user>
       mqtt.password=<path:factory-x-ci-cd/data/async-aas#broker-pw>
-      mqtt.ws_path=/ws  # TODO must be implemented in Basyx
       
       basyx.feature.authorization.enabled = true
       basyx.feature.authorization.type = rbac
@@ -398,7 +397,7 @@ rabbitmq:
     vm_memory_high_watermark.relative = 0.8
 
     web_mqtt.tcp.port = 9001
-    web_mqtt.ws_path = /ws
+    web_mqtt.ws_path = /mqtt  # this MUST be set for Basyx (paho default, non-configurable in basyx)
 
     mqtt.vhost = /
     mqtt.exchange = amq.topic
@@ -424,7 +423,7 @@ rabbitmq:
       - host: <path:factory-x-ci-cd/data/async-aas#broker-url>
         http:
           paths:
-            - path: /ws
+            - path: /mqtt
               pathType: ImplementationSpecific
               backend:
                 service:

--- a/values.yaml
+++ b/values.yaml
@@ -419,6 +419,8 @@ aas-basyx-v2-full:
     enabled: false
 
 rabbitmq:
+  fullnameOverride: rabbitmq
+
   image:
     debug: false
 
@@ -485,11 +487,12 @@ rabbitmq:
               pathType: ImplementationSpecific
               backend:
                 service:
-                  name: rabbitmqttbroker-websockets-service  # TODO verify whether this just works or if we need to use "fullnameOverride"
-                  port: 9001
+                  name: rabbitmq
+                  port:
+                    number: 9001
 
     # need to use extraTls because the regular "tls" block is only for management interface
     extraTls:
       - hosts:
         - <path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-url>
-        secretName: chart-example-tls  # TODO taken from basyx-mqtt config, does this need a CI variable?
+        secretName: chart-example-tls


### PR DESCRIPTION
This PR adds a RabbitMQ deployment to the Async AAS. For now, neither FA3ST nor Basyx are configured to use it. That would be the next step after confirming that this deployment is successful.

The RabbitMQ Broker assumes the following CI variables to be defined:

- rabbitmq-broker-url
- rabbitmq-broker-user
- rabbitmq-broker-pw