### PR TITLE
feat: Keycloak-RabbitMQ integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 Chart.lock
-charts/*.tgz
+**/charts/*.tgz

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 2.0.6
     repository: "https://eclipse-basyx.github.io/charts/"
   - name: rabbitmq
-    version: 16.0.11
+    version: 16.0.14
     repository: "https://charts.bitnami.com/bitnami"
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/async-aas-helm/config/rabbitmq-realm.json
+++ b/charts/async-aas-helm/config/rabbitmq-realm.json
@@ -1,0 +1,102 @@
+{
+    "realm": "rabbitmq-realm",
+    "enabled": true,
+    "clients": [
+        {
+            "clientId": "CLIENTID-PLACEHOLDER",
+            "enabled": true,
+            "protocol": "openid-connect",
+            "clientAuthenticatorType": "client-secret",
+            "secret": "CLIENTSECRET-PLACEHOLDER",
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "publicClient": false,
+            "redirectUris": [
+                "*"
+            ],
+            "webOrigins": [
+                "*"
+            ],
+            "protocolMappers": [
+                {
+                    "name": "aud",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "included.client.audience": "rabbitmq",
+                        "id.token.claim": "false",
+                        "access.token.claim": "true",
+                        "userinfo.token.claim": "false"
+                    }
+                }
+            ],
+            "defaultClientScopes": [
+                "rabbitmq.configure:*/*/*",
+                "rabbitmq.write:*/*/*",
+                "rabbitmq.read:*/*/*"
+            ],
+            "optionalClientScopes": []
+        },
+        {
+            "clientId": "rabbitmq",
+            "name": "",
+            "description": "",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": true,
+            "protocol": "openid-connect",
+            "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "post.logout.redirect.uris": "+",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": true,
+            "nodeReRegistrationTimeout": -1,
+            "defaultClientScopes": [],
+            "optionalClientScopes": []
+        }
+    ],
+    "clientScopes": [
+        {
+            "name": "rabbitmq.configure:*/*/*",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true"
+            },
+            "protocolMappers": []
+        },
+        {
+            "name": "rabbitmq.write:*/*/*",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true"
+            },
+            "protocolMappers": []
+        },
+        {
+            "name": "rabbitmq.read:*/*/*",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true"
+            },
+            "protocolMappers": []
+        }
+    ]
+}

--- a/charts/async-aas-helm/templates/basyx-keycloak-rabbitmq-realm.yaml
+++ b/charts/async-aas-helm/templates/basyx-keycloak-rabbitmq-realm.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-realm
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  rabbitmq-realm.json: |-
+{{- $file := .Files.Get "config/rabbitmq-realm.json" }}
+{{- $clientId := index (index (index .Values "aas-basyx-v2-full") "keycloak") "mqttClientId" }}
+{{- $clientSecret := index (index (index .Values "aas-basyx-v2-full") "keycloak") "mqttClientSecret" }}
+{{- $replaced := ($file | replace "CLIENTID-PLACEHOLDER" $clientId | replace "CLIENTSECRET-PLACEHOLDER" $clientSecret) }}
+{{ $replaced | nindent 4 }}

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -113,7 +113,18 @@ aas-basyx-v2-full:
     auth:
       adminUser: <path:factory-x-ci-cd/data/async-aas#keycloak-user>
       adminPassword: <path:factory-x-ci-cd/data/async-aas#keycloak-pw>
-    args: ["/bin/sh -c 'kc.sh import --file /opt/keycloak/data/import/BaSyx-realm.json; kc.sh start-dev --hostname-strict=false --proxy-headers=xforwarded --http-enabled=true --features=token-exchange'"]
+    extraVolumes:
+      - name: rabbitmq-realm
+        configMap:
+          name: rabbitmq-realm
+    extraVolumeMounts:
+      - mountPath: /opt/keycloak/data/import/rabbitmq-realm.json
+        subPath: rabbitmq-realm.json
+        name: rabbitmq-realm
+    args: ["/bin/sh -c 'kc.sh import --file /opt/keycloak/data/import/BaSyx-realm.json; kc.sh import --file /opt/keycloak/data/import/rabbitmq-realm.json; kc.sh start-dev --hostname-strict=false --proxy-headers=xforwarded --http-enabled=true --features=token-exchange'"]
+
+    mqttClientId: <path:factory-x-ci-cd/data/async-aas#keycloak-mqtt-clientid>
+    mqttClientSecret: <path:factory-x-ci-cd/data/async-aas#keycloak-mqtt-clientsecret>
 
   aas-registry:
     enabled: true
@@ -452,10 +463,11 @@ rabbitmq:
     username: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-pw>"
     updatePassword: true
+    enableLoopbackUser: false  # setting this to "true" disables login via this user from remote hosts
 
-  # Enable MQTT + Websockets
-  extraPlugins: "rabbitmq_mqtt rabbitmq_web_mqtt"
-
+  # Enable MQTT, Websockets, and OAuth
+  extraPlugins: "rabbitmq_mqtt rabbitmq_web_mqtt rabbitmq_auth_backend_oauth2"
+  
   # configure memory usage threshold for warnings
   # memoryHighWatermark:
   #   enabled: true
@@ -474,6 +486,19 @@ rabbitmq:
     mqtt.allow_anonymous = false
 
     #log.default.level = debug
+
+    auth_backends.1 = internal
+    auth_backends.2 = rabbit_auth_backend_oauth2
+
+    auth_oauth2.resource_server_id = rabbitmq  # this must correspond to the "aud" claim of the JWT
+
+    # rabbit looks for the client's username in these claims
+    auth_oauth2.preferred_username_claims.1 = user_name
+    auth_oauth2.preferred_username_claims.2 = clientId
+    auth_oauth2.preferred_username_claims.3 = azp
+
+    auth_oauth2.issuer = https://<path:factory-x-ci-cd/data/async-aas#keycloak-url>/realms/rabbitmq-realm
+    auth_oauth2.additional_scopes_key = extra_scope
 
   ingress:
     enabled: true


### PR DESCRIPTION
This PR creates a new "rabbitmq-realm" in the Basyx Keycloak instance that is integrated with the previously deployed RabbitMQ instance, enabling OAuth for MQTT via RabbitMQ.

The workflow for this, i.e., what does a client have to do to use OAuth for MQTT, will be documented in [Confluence](https://factory-x.atlassian.net/wiki/spaces/TP4/pages/292192477/Security+Best+Practices#RabbitMQ-Keycloak-Integration-in-Async-AAS-Repository)

We use two new CD variables:
* keycloak-mqtt-clientid
* keycloak-mqtt-clientsecret