### PR TITLE
fix: restore BaSyx realm import

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -114,10 +114,16 @@ aas-basyx-v2-full:
       adminUser: <path:factory-x-ci-cd/data/async-aas#keycloak-user>
       adminPassword: <path:factory-x-ci-cd/data/async-aas#keycloak-pw>
     extraVolumes:
+      - name: basyx-keycloak-realm
+        configMap:
+          name: basyx-keycloak-realm
       - name: rabbitmq-realm
         configMap:
           name: rabbitmq-realm
     extraVolumeMounts:
+      - mountPath: /opt/keycloak/data/import/BaSyx-realm.json
+        subPath: BaSyx-realm.json
+        name: basyx-keycloak-realm
       - mountPath: /opt/keycloak/data/import/rabbitmq-realm.json
         subPath: rabbitmq-realm.json
         name: rabbitmq-realm


### PR DESCRIPTION
This PR fixes a broken BaSyx Keycloak Realm import by re-adding it. #55 broke it due to overwriting the ConfigMap mount of BaSyx without the existing import in mind