### PR TITLE
fix: change topic structure

### DIFF
--- a/specs/asyncapi_spec_aas.yaml
+++ b/specs/asyncapi_spec_aas.yaml
@@ -7,8 +7,7 @@ info:
     asset administration shell are transmitted to the MQTT broker.
 channels:
   aas/update/valuechanged:
-    address: >-
-      uri:aas:shells/{aasid}/submodels/{submodelid}/submodel-elements/{smec-idshort.property-idshort}
+    address: noauth or all or participantid
     messages:
       publish.message:
         $ref: '#/components/messages/valueChanged'
@@ -20,7 +19,7 @@ channels:
       smec-idshort.property-idshort:
         $ref: '#/components/parameters/smec-idshort.property-idshort'
   aas/update/elementcreated:
-    address: aas/update/elementcreated
+    address: noauth or all or participantid
     messages:
       publish.message:
         $ref: '#/components/messages/elementCreated'

--- a/specs/asyncapi_spec_submodel.yaml
+++ b/specs/asyncapi_spec_submodel.yaml
@@ -4,8 +4,7 @@ info:
   version: 0.3-SNAPSHOT
 channels:
   submodel/update/valuechanged:
-    address: >-
-      uri:submodels/base64{submodelid}/submodel-elements/{smec-idshort.property-idshort}
+    address: noauth or all or participantid
     messages:
       publish.message:
         $ref: '#/components/messages/valueChanged'
@@ -15,7 +14,7 @@ channels:
       smec-idshort.property-idshort:
         $ref: '#/components/parameters/smec-idshort.property-idshort'
   submodel/update/elementcreated:
-    address: submodel/update/elementcreated
+    address: noauth or all or participantid
     messages:
       publish.message:
         $ref: '#/components/messages/elementCreated'


### PR DESCRIPTION
## WHAT

there's still old topic structure in the spec documents.

## WHY

Discussions in the spec group led to the responsibility for access control to be placed on the publisher. The broker only routs and distributes.

Closes #16