### PR TITLE
feat: submodel element spec for ValueChanged

### DIFF
--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -112,3 +112,6 @@ components:
                 - number
               examples:
                 - 42
+            dataType:
+              type: string
+              example: xs:string

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -31,9 +31,9 @@ components:
         $ref: '#/components/schemas/valueChangedEvent'
   parameters:
     submodelid:
-      description: The Id of the submodel in the Asset Administration Shell with aasId.
+      description: The ID of the submodel from which the event originates.
     idshortpath:
-      description: The idShortPath of a property within a Submodel.
+      description: The idShortPath to the emitting SubmodelElement.
   schemas:
     valueChangedEvent:
       properties:
@@ -79,8 +79,8 @@ components:
           type: string
           examples:
             - '2025-09-25T13:37:12.3456789+01:00'
-        semanticId:
-          description: The semanticId of the submodel in which the event took place, if available. This property may hold the entry in the semanticId's `keys`-array at index 0
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
           type: string
           examples:
             - "0173-1#02-AAA119#002"
@@ -105,23 +105,10 @@ components:
                 - string
                 - number
               examples:
-                - OldDataValue
+                - 41
             newValue:
               type: 
                 - string
                 - number
               examples:
-                - NewDataValue
-            dataType:
-              type: string
-              example: xs:string
-            value:
-              type:
-                - string
-                - number
-              examples:
-                - Christian X
-            idShort:
-              type: string
-              examples:
-                - property-idShort
+                - 42

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -1,0 +1,127 @@
+asyncapi: 3.0.0
+info:
+  title: AAS SubmodelElement ASYNC API with CloudEvents
+  version: 0.3-SNAPSHOT
+channels:
+  submodelelement/update/valuechanged:
+    address: >-
+      uri:submodels/base64{submodelid}/submodel-elements/{idshortpath}
+    messages:
+      publish.message:
+        $ref: '#/components/messages/valueChanged'
+    parameters:
+      submodelid:
+        $ref: '#/components/parameters/submodelid'
+      idshortpath:
+        $ref: '#/components/parameters/idshortpath'
+operations:
+  submodelelement/update/valuechanged.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1valuechanged'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1valuechanged/messages/publish.message'
+components:
+  messages:
+    valueChanged:
+      name: SubmodelElementValueChanged
+      title: SubmodelElement Value Change message
+      summary: Emitted when the 'value' field of a submodel element is changed
+      payload:
+        $ref: '#/components/schemas/valueChangedEvent'
+  parameters:
+    submodelid:
+      description: The Id of the submodel in the Asset Administration Shell with aasId.
+    idshortpath:
+      description: The idShortPath of a property within a Submodel.
+  schemas:
+    valueChangedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the emitting Referable can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.emitting.dataelelement'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event
+            originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.PropertyValueChanged
+            - io.admin-shell.events.v1.FileValueChanged
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/File
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticId:
+          description: The semanticId of the submodel in which the event took place, if available. This property may hold the entry in the semanticId's `keys`-array at index 0
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/valueChangedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    valueChangedEventData:
+          type: object
+          properties:
+            oldValue:
+              type: 
+                - string
+                - number
+              examples:
+                - OldDataValue
+            newValue:
+              type: 
+                - string
+                - number
+              examples:
+                - NewDataValue
+            dataType:
+              type: string
+              example: xs:string
+            value:
+              type:
+                - string
+                - number
+              examples:
+                - Christian X
+            idShort:
+              type: string
+              examples:
+                - property-idShort

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -29,6 +29,16 @@ channels:
     messages:
       publish.message:
         $ref: '#/components/messages/elementDeleted'
+  submodelelement/update/operationinvoked:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/operationInvoked'
+  submodelelement/update/operationfinished:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/operationFinished'
 operations:
   submodelelement/update/valuechanged.publish:
     action: send
@@ -60,6 +70,18 @@ operations:
       $ref: '#/channels/submodelelement~1update~1elementdeleted'
     messages:
       - $ref: '#/channels/submodelelement~1update~1elementdeleted/messages/publish.message'
+  submodelelement/update/operationinvoked.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1operationinvoked'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1operationinvoked/messages/publish.message'
+  submodelelement/update/operationfinished.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1operationfinished'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1operationfinished/messages/publish.message'
 components:
   messages:
     valueChanged:
@@ -92,6 +114,18 @@ components:
       summary: Triggered when an element is deleted
       payload:
         $ref: '#/components/schemas/elementDeletedEvent'
+    operationInvoked:
+      name: OperationInvoked
+      title: Operation Invoke message
+      summary: Triggered when an operation is invoked
+      payload:
+        $ref: '#/components/schemas/operationInvokedEvent'
+    operationFinished:
+      name: OperationFinished
+      title: Operation Finish message
+      summary: Triggered when an operation is finished
+      payload:
+        $ref: '#/components/schemas/operationFinishedEvent'
   schemas:
     valueChangedEvent:
       properties:
@@ -197,8 +231,8 @@ components:
             Describes the type of the event related to the source the event originated in.
           type: string
           examples:
-            - io.admin-shell.events.v1.PropertyRead
-            - io.admin-shell.events.v1.SubmodelElementCollectionRead
+            - io.admin-shell.events.v1.PropertyCreated
+            - io.admin-shell.events.v1.SubmodelElementCollectionCreated
         datacontenttype:
           description: Content type of the event data.
           type: string
@@ -258,8 +292,8 @@ components:
             Describes the type of the event related to the source the event originated in.
           type: string
           examples:
-            - io.admin-shell.events.v1.PropertyCreated
-            - io.admin-shell.events.v1.SubmodelElementCollectionCreated
+            - io.admin-shell.events.v1.PropertyRead
+            - io.admin-shell.events.v1.SubmodelElementCollectionRead
         datacontenttype:
           description: Content type of the event data.
           type: string
@@ -426,3 +460,165 @@ components:
                 - '{"idShort":"MyVariableProperty", "value": 42}'
               description:
                 The emitting referable element in full.
+    operationInvokedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the operation element can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.operation.element'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.OperationInvoked
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Operation
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/operationInvokedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    operationInvokedEventData:
+      type: object
+      properties:
+        inputArguments:
+          $ref: '#/components/schemas/inputArguments'
+        inoutputArguments:
+          $ref: '#/components/schemas/inoutputArguments'
+        outputArguments:
+          $ref: '#/components/schemas/outputArguments'
+    operationFinishedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the operation element can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.operation.element'
+        type:
+          description: >-
+            Describes the type of the event.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.OperationFinished
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Operation
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/operationFinishedEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    operationFinishedEventData:
+      type: object
+      properties:
+        inoutputArguments:
+          $ref: '#/components/schemas/inoutputArguments'
+        outputArguments:
+          $ref: '#/components/schemas/outputArguments'
+    inputArguments:
+      items:
+        description: List of OperationVariables declared as inputArguments.
+        type: string
+      examples:
+        - '[ {"idShort":"MyFirstInputArgument", "value": 42}, {"idShort":"MySecondInputArgument", "value": "hello-world"} ]'
+        - '[{"in": 4}]'
+      description:
+        The supplied input variable(s) for an operation invocation.
+      type: array
+    inoutputArguments:
+      items:
+        description: List of OperationVariables declared as inoutputArguments.
+        type: string
+      examples:
+        - '[ {"idShort":"MyInoutputArgument", "value": 100} ]'
+        - '[{"note": "original value"}]'
+      description:
+        The supplied inoutput variable(s) for an operation invocation.
+      type: array
+    outputArguments:
+      items:
+        description: List of OperationVariables declared as outputArguments.
+        type: string
+      examples:
+        - '[ {"idShort":"MyOperationOutput", "value": 123456} ]'
+        - '[{"note": "new value"}]'
+      description:
+        The output variable(s) as the operation result.
+      type: array

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -2,18 +2,33 @@ asyncapi: 3.0.0
 info:
   title: AAS SubmodelElement ASYNC API with CloudEvents
   version: 0.3-SNAPSHOT
+  description: This API describes SubmodelElement-level events emitted by an AAS Repository/Service.
 channels:
   submodelelement/update/valuechanged:
-    address: >-
-      uri:submodels/base64{submodelid}/submodel-elements/{idshortpath}
+    address: noauth or all or participantid
     messages:
       publish.message:
         $ref: '#/components/messages/valueChanged'
-    parameters:
-      submodelid:
-        $ref: '#/components/parameters/submodelid'
-      idshortpath:
-        $ref: '#/components/parameters/idshortpath'
+  submodelelement/update/elementcreated:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/elementCreated'
+  submodelelement/update/elementread:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/elementRead'
+  submodelelement/update/elementupdated:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/elementUpdated'
+  submodelelement/update/elementdeleted:
+    address: noauth or all or participantid
+    messages:
+      publish.message:
+        $ref: '#/components/messages/elementDeleted'
 operations:
   submodelelement/update/valuechanged.publish:
     action: send
@@ -21,19 +36,62 @@ operations:
       $ref: '#/channels/submodelelement~1update~1valuechanged'
     messages:
       - $ref: '#/channels/submodelelement~1update~1valuechanged/messages/publish.message'
+  submodelelement/update/elementcreated.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1elementcreated'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1elementcreated/messages/publish.message'
+  submodelelement/update/elementread.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1elementread'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1elementread/messages/publish.message'
+  submodelelement/update/elementupdated.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1elementupdated'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1elementupdated/messages/publish.message'
+  submodelelement/update/elementdeleted.publish:
+    action: send
+    channel:
+      $ref: '#/channels/submodelelement~1update~1elementdeleted'
+    messages:
+      - $ref: '#/channels/submodelelement~1update~1elementdeleted/messages/publish.message'
 components:
   messages:
     valueChanged:
       name: SubmodelElementValueChanged
       title: SubmodelElement Value Change message
-      summary: Emitted when the 'value' field of a submodel element is changed
+      summary: Triggered when the value of an element is updated
       payload:
         $ref: '#/components/schemas/valueChangedEvent'
-  parameters:
-    submodelid:
-      description: The ID of the submodel from which the event originates.
-    idshortpath:
-      description: The idShortPath to the emitting SubmodelElement.
+    elementCreated:
+      name: SubmodelElementUpdated
+      title: SubmodelElement Create message
+      summary: Triggered when an element is created
+      payload:
+        $ref: '#/components/schemas/elementCreatedEvent'
+    elementRead:
+      name: SubmodelElementRead
+      title: SubmodelElement Read message
+      summary: Triggered when an element is read
+      payload:
+        $ref: '#/components/schemas/elementReadEvent'
+    elementUpdated:
+      name: SubmodelElementUpdated
+      title: SubmodelElement Update message
+      summary: Triggered when an element is updated
+      payload:
+        $ref: '#/components/schemas/elementUpdatedEvent'
+    elementDeleted:
+      name: SubmodelElementUpdated
+      title: SubmodelElement Delete message
+      summary: Triggered when an element is deleted
+      payload:
+        $ref: '#/components/schemas/elementDeletedEvent'
   schemas:
     valueChangedEvent:
       properties:
@@ -54,8 +112,7 @@ components:
             - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.emitting.dataelelement'
         type:
           description: >-
-            Describes the type of the event related to the source the event
-            originated in.
+            Describes the type of the event related to the source the event originated in.
           type: string
           examples:
             - io.admin-shell.events.v1.PropertyValueChanged
@@ -106,12 +163,266 @@ components:
                 - number
               examples:
                 - 41
+              description: The old value of the SubmodelElement.
             newValue:
               type: 
                 - string
                 - number
               examples:
                 - 42
+              description: The new value of the SubmodelElement.
             dataType:
               type: string
-              example: xs:string
+              example: xs:int
+              description: The data type of the changed value. If the data type changed, the new data type.
+    elementCreatedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the emitting Referable can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.emitting.referable'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.PropertyRead
+            - io.admin-shell.events.v1.SubmodelElementCollectionRead
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/File
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/wholeElementEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    elementReadEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the emitting Referable can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.emitting.referable'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.PropertyCreated
+            - io.admin-shell.events.v1.SubmodelElementCollectionCreated
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/File
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/wholeElementEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    elementUpdatedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL the emitting Referable can be obtained from.
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.emitting.referable'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event
+            originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.PropertyUpdated
+            - io.admin-shell.events.v1.SubmodelElementCollectionUpdated
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/File
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+        data:
+          $ref: '#/components/schemas/wholeElementEventData'
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - data
+        - semanticid
+    elementDeletedEvent:
+      properties:
+        specversion:
+          description: The version of the CloudEvents specification which the event uses.
+          type: string
+          const: '1.0'
+        id:
+          description: Identifies the event.
+          type: string
+          examples:
+            - 358c02f2-3a11-4836-971b-43a05550bf97
+        source:
+          description: The URL of the referable in which the emitting referable **was contained**
+          type: string
+          pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
+          examples:
+            - 'https://providercorp.com/submodels/b64encoded-id/submodel-elements/idshort.path.to.containing.referable'
+            - 'https://providercorp.com/submodels/b64encoded-id'
+        type:
+          description: >-
+            Describes the type of the event related to the source the event originated in.
+          type: string
+          examples:
+            - io.admin-shell.events.v1.PropertyDeleted
+            - io.admin-shell.events.v1.SubmodelElementCollectionDeleted
+        datacontenttype:
+          description: Content type of the event data.
+          type: string
+          const: application/json
+        dataschema:
+          description: Identifies the schema that the event data adheres to.
+          type: string
+          format: uri
+          examples:
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property
+            - >-
+              https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/File
+        time:
+          description: Timestamp of when the occurrence happened.
+          format: date-time
+          type: string
+          examples:
+            - '2025-09-25T13:37:12.3456789+01:00'
+        semanticid:
+          description: The semanticId of the submodel from which the event was emitted, if available. (This property may hold the entry in the semanticId's `keys`-array at index 0)
+          type: string
+          examples:
+            - "0173-1#02-AAA119#002"
+      required:
+        - specversion
+        - id
+        - source
+        - type
+        - datacontenttype
+        - dataschema
+        - time
+      optional:
+        - semanticid
+    wholeElementEventData:
+          type: object
+          properties:
+            element: 
+              examples:
+                - '{"idShort":"MyVariableProperty", "value": 42}'
+              description:
+                The emitting referable element in full.


### PR DESCRIPTION
## WHAT

Adds `SubmodelElement Value Changed`, `SubmodelElementCRUD`, `Operation` event types. Adopted from SubmodelValueChange event, but slimmed down. (See the running example here: https://studio.asyncapi.com/?share=53e8ee8b-67b4-4233-84cc-dabe03589526)

1. `data` field inspired by `FA³ST`: Only `oldValue`, `newValue` (and `dataType`).
    Removed `modelType`, `idShort` from the `data` field due to redundancy (They are available in the event metadata)
2. Added semanticId of the submodel that contains the emitting SubmodelElement
3. Event type is specific to the SubmodelElement type:
    ```
    "io.admin-shell.events.v1.PropertyValueChanged"
    "io.admin-shell.events.v1.FileValueChanged"
    ...
    ```
    This could also be changed to SubmodelElementChanged for all SubmodelElement types. (Then modelType would need to be added to the `data` field again)

## WHY

Need to specify more messages

## FURTHER NOTES

See the running example here: https://studio.asyncapi.com/?share=53e8ee8b-67b4-4233-84cc-dabe03589526