### PR TITLE
feat: show SubmodelElement events

### DIFF
--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -89,5 +89,14 @@
   <a href="./submodel-repository/" class="button">Events emitted by <b>Submodel Repositories</b></a>
 
 </p>
+<p>
+  <a>
+
+  </a>
+</p>
+<p>
+  <a href="./submodel-repository-submodelelement/" class="button"><b>SubmodelElement-level</b> Events emitted by <b>Submodel Repositories</b></a>
+
+</p>
 </body>
 </html>

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,13 @@ jobs:
           filepath: specs/asyncapi_spec_submodel.yaml
           output: submodel-repository
 
+      - name: Generating HTML for SubmodelElements document
+        uses: asyncapi/cli@v3.2.0
+        with:
+          template: '@asyncapi/html-template@2.3.14'
+          filepath: specs/asyncapi_spec_submodelelement.yaml
+          output: submodel-repository-submodelelement
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .


### PR DESCRIPTION
## WHAT

Last PR did not make the new Events visible on the GH pages site.

Now it does (see my fork): https://carlos-schmidt.github.io/async-aas-helm/

## WHY

Visibility

## FURTHER NOTES

--