### PR TITLE
fix: reduce event types for submodel and aas spec

### DIFF
--- a/specs/asyncapi_spec_aas.yaml
+++ b/specs/asyncapi_spec_aas.yaml
@@ -70,7 +70,7 @@ components:
           examples:
             - 358c02f2-3a11-4836-971b-43a05550bf97
         source:
-          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `datacontenttype` property.
+          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `dataschema` property.
           type: string
           pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
           examples:
@@ -154,7 +154,7 @@ components:
           examples:
             - ecbd132e-d834-4528-bb30-6790104ca474
         source:
-          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `datacontenttype` property.
+          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `dataschema` property.
           type: string
           pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
           examples:

--- a/specs/asyncapi_spec_submodel.yaml
+++ b/specs/asyncapi_spec_submodel.yaml
@@ -63,7 +63,7 @@ components:
           examples:
             - 358c02f2-3a11-4836-971b-43a05550bf97
         source:
-          description: The URL the emitting Referable can be obtained from. The element must be of the type indicated in the `datacontenttype` property.
+          description: The URL the emitting Referable can be obtained from. The element must be of the type indicated in the `dataschema` property.
           type: string
           pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
           examples:
@@ -76,8 +76,6 @@ components:
           enum:
             - io.admin-shell.events.v1.created
             - io.admin-shell.events.v1.updated
-            - io.admin-shell.events.v1.deleted
-          examples:
             - io.admin-shell.events.v1.deleted
         datacontenttype:
           description: Content type of the event data.
@@ -147,7 +145,7 @@ components:
           examples:
             - ecbd132e-d834-4528-bb30-6790104ca474
         source:
-          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `datacontenttype` property.
+          description: The URL the emitting element can be obtained from. The element must be of the type indicated in the `dataschema` property.
           type: string
           pattern: ^https?:\/\/[^\s/$.?#].[^\s]*$
           examples:
@@ -161,8 +159,6 @@ components:
           enum:
             - io.admin-shell.events.v1.created
             - io.admin-shell.events.v1.updated
-            - io.admin-shell.events.v1.deleted
-          examples:
             - io.admin-shell.events.v1.deleted
         datacontenttype:
           description: Content type of the event data.


### PR DESCRIPTION
## WHAT

closes #73 

## WHY

Remove redunant reference to the meta-model type

## FURTHER NOTES

There's still a discussion to be had about submodel elements as the `Operation` SME requires different semantics than CRUD.