### PR TITLE
fix: connection FA3ST-Rabbit

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,7 +3,7 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 0.1.6
+    version: 0.1.7
     repository: "file://../faaast-service"
   - name: faaast-registry
     version: 0.2.0
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -48,10 +48,11 @@ faaast-service:
 
   messageBus:
     class: "de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudevents"
-    host: "wss://<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-url>:443/mqtt"
+    host: "wss://<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-url>:443"
     user: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-user>"
     password: "<path:factory-x-ci-cd/data/async-aas#rabbitmq-broker-pw>"
     eventCallbackAddress: "<path:factory-x-ci-cd/data/async-aas#faaast-service-url>/api/v3.0"
+    topicPrefix: "mqtt/noauth"
 
   ingress:
     annotations:

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/templates/configmap.yaml
+++ b/charts/faaast-service/templates/configmap.yaml
@@ -26,7 +26,8 @@ data:
         "user": "{{ .Values.messageBus.user }}",
         "password": "{{ .Values.messageBus.password }}",
         "slimEvents": "{{ .Values.messageBus.slimEvents }}",
-        "eventCallbackAddress": "{{ .Values.messageBus.eventCallbackAddress }}"
+        "eventCallbackAddress": "{{ .Values.messageBus.eventCallbackAddress }}",
+        "topicPrefix": "{{ .Values.messageBus.topicPrefix }}"
       },
       "endpoints": [
         {

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -56,6 +56,7 @@ messageBus:
   password: ""
   slimEvents: true
   eventCallbackAddress: ""
+  topicPrefix: ""
 
 endpoints:
   - class: "de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.HttpEndpoint"


### PR DESCRIPTION
## WHAT

Fixes connection to rabbit caused by mqtt topic prefix "mqtt"

## WHY

No connection possible from fa3st to rabbit mqtt broker

## FURTHER NOTES

Closes #86 