### PR TITLE
fix: fa3st dtr service port

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
     version: 0.1.7
     repository: "file://../faaast-service"
   - name: faaast-registry
-    version: 0.2.0
+    version: 0.2.1
     repository: "file://../faaast-registry"
   - name: aas-basyx-v2-full
     version: 2.1.11
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-registry/Chart.yaml
+++ b/charts/faaast-registry/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-registry/templates/service.yaml
+++ b/charts/faaast-registry/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 8080
+      targetPort: {{ .Values.server.port }}
       protocol: TCP
       name: https
   selector:


### PR DESCRIPTION
## WHAT

Fixes FA³ST Registry deployment by setting correct service port (configurable)

## WHY

502 for registry calls

## FURTHER NOTES

no