### PR TITLE
fix: empty configmaps

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.6.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/templates/basyx-keycloak-rabbitmq-realm.yaml
+++ b/charts/async-aas-helm/templates/basyx-keycloak-rabbitmq-realm.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   rabbitmq-realm.json: |-
-{{- $file := .Files.Get "config/rabbitmq-realm.json" | nindent 4 }}
+{{- (.Files.Get "config/rabbitmq-realm.json") | nindent 4 }}

--- a/charts/async-aas-helm/templates/basyx-keycloak-realm.yaml
+++ b/charts/async-aas-helm/templates/basyx-keycloak-realm.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   BaSyx-realm.json: |-
-{{- $file := .Files.Get "config/BaSyx-realm.json" | nindent 4 }}
+{{- (.Files.Get "config/BaSyx-realm.json") | nindent 4 }}

--- a/charts/async-aas-helm/templates/fa3st-service-realm.yaml
+++ b/charts/async-aas-helm/templates/fa3st-service-realm.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   fa3st-service-realm.json: |-
-{{- $file := .Files.Get "config/fa3st-service-realm.json" | nindent 4 }}
+{{- (.Files.Get "config/fa3st-service-realm.json") | nindent 4 }}


### PR DESCRIPTION
## WHAT

Fixes empty config map issue due to wrong realm-template yaml-files.

```sh
I have no name!@basyx-keycloak-0:/opt/keycloak/data/import$ ls
BaSyx-realm.json  fa3st-service-realm.json  rabbitmq-realm.json
I have no name!@basyx-keycloak-0:/opt/keycloak/data/import$ cat BaSyx-realm.json |wc -l
48
I have no name!@basyx-keycloak-0:/opt/keycloak/data/import$ cat fa3st-service-realm.json |wc -l
50
I have no name!@basyx-keycloak-0:/opt/keycloak/data/import$ cat rabbitmq-realm.json |wc -l
101
```

## WHY

Realms are not being loaded into Keycloak at deploy time

## FURTHER NOTES

Also relevant logs:

```log
INFO  [...] (main) Full importing from file /opt/keycloak/data/import/BaSyx-realm.json
INFO  [...] (main) Realm 'basyx' imported
...
INFO  [...] (main) Full importing from file /opt/keycloak/data/import/rabbitmq-realm.json
INFO  [...] (main) Realm 'rabbitmq-realm' imported
...
INFO  [...] (main) Full importing from file /opt/keycloak/data/import/fa3st-service-realm.json
INFO  [...] (main) Realm 'fa3st' imported
```