### PR TITLE
fix: trust config to keycloak

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.6
+version: 0.6.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -252,7 +252,7 @@ aas-basyx-v2-full:
       basyx.feature.authorization.type=rbac
       basyx.feature.authorization.jwtBearerTokenProvider=keycloak
       basyx.feature.authorization.rbac.file=file:/application/rbac-rules.json
-      spring.security.oauth2.resourceserver.jwt.issuer-uri=https://<path:factory-x-ci-cd/data/async-aas#keycloak-url>/realms/BaSyx
+      spring.security.oauth2.resourceserver.jwt.issuer-uri=https://<path:factory-x-ci-cd/data/async-aas#keycloak-url>/realms/basyx
     ingress:
       enabled: true
       host: "<path:factory-x-ci-cd/data/async-aas#basyx-disco-url>"
@@ -630,7 +630,7 @@ rabbitmq:
     auth_oauth2.preferred_username_claims.2 = clientId
     auth_oauth2.preferred_username_claims.3 = azp
 
-    auth_oauth2.issuer = https://<path:factory-x-ci-cd/data/async-aas#keycloak-url>/realms/rabbitmq-realm
+    auth_oauth2.issuer = https://<path:factory-x-ci-cd/data/async-aas#keycloak-url>/realms/rabbitmq
     auth_oauth2.additional_scopes_key = extra_scope
 
   ingress:


### PR DESCRIPTION
## WHAT

the updated realm names (#110) caused rabbitmq and basyx to be configured to trust realms that didn't exist anymore. This PR realigns that. Now they link

https://keycloak.basyx.factory-x.catena-x.net/realms/rabbitmq/
instead of 
https://keycloak.basyx.factory-x.catena-x.net/realms/rabbitmq-realm

and 

https://keycloak.basyx.factory-x.catena-x.net/realms/basyx
instead of 
https://keycloak.basyx.factory-x.catena-x.net/realms/BaSyx

