### PR TITLE
feat: add optional auth header for registry synchronization

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,7 +3,7 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 0.2.5
+    version: 0.2.6
     repository: "file://../faaast-service"
   - name: faaast-registry
     version: 0.2.3

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,7 +3,7 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 0.2.4
+    version: 0.2.5
     repository: "file://../faaast-service"
   - name: faaast-registry
     version: 0.2.3
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.12
+version: 0.6.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,7 +3,7 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 0.2.6
+    version: 0.2.5
     repository: "file://../faaast-service"
   - name: faaast-registry
     version: 0.2.3

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -52,6 +52,13 @@ faaast-service:
     aasRegistryBaseUrl: "http://faaast-registry:443"
     submodelRegistryBaseUrl: "http://faaast-registry:443"
 
+  # Optional: add auth header for registry synchronization requests (e.g. Basic auth for ingress-protected registry)
+  registrySynchronization:
+    auth:
+      header:
+        name: ""
+        value: ""
+
   persistence:
     host: "mongodb"
     port: "27017"

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/templates/configmap.yaml
+++ b/charts/faaast-service/templates/configmap.yaml
@@ -9,10 +9,7 @@ data:
     {
       "core": {
         {{- if .Values.registry.aasRegistryBaseUrl }}
-        "aasRegistries": ["{{ .Values.registry.aasRegistryBaseUrl }}"]{{- if .Values.registry.submodelRegistryBaseUrl }},{{ end }}
-        {{- end }}
-        {{- if .Values.registry.submodelRegistryBaseUrl }}
-        "submodelRegistries": ["{{ .Values.registry.submodelRegistryBaseUrl }}"]{{- if and .Values.registrySynchronization.auth.header.name .Values.registrySynchronization.auth.header.value }},{{ end }}
+        "aasRegistries": ["{{ .Values.registry.aasRegistryBaseUrl }}"]{{- if or .Values.registry.submodelRegistryBaseUrl (and .Values.registrySynchronization.auth.header.name .Values.registrySynchronization.auth.header.value) }},{{ end }}
         {{- end }}
         {{- if and .Values.registrySynchronization.auth.header.name .Values.registrySynchronization.auth.header.value }}
         "registrySynchronization": {
@@ -22,7 +19,10 @@ data:
               "value": "{{ .Values.registrySynchronization.auth.header.value }}"
             }
           }
-        }
+        }{{- if .Values.registry.submodelRegistryBaseUrl }},{{ end }}
+        {{- end }}
+        {{- if .Values.registry.submodelRegistryBaseUrl }}
+        "submodelRegistries": ["{{ .Values.registry.submodelRegistryBaseUrl }}"]
         {{- end }}
       },
       "persistence": {

--- a/charts/faaast-service/templates/configmap.yaml
+++ b/charts/faaast-service/templates/configmap.yaml
@@ -12,7 +12,17 @@ data:
         "aasRegistries": ["{{ .Values.registry.aasRegistryBaseUrl }}"]{{- if .Values.registry.submodelRegistryBaseUrl }},{{ end }}
         {{- end }}
         {{- if .Values.registry.submodelRegistryBaseUrl }}
-        "submodelRegistries": ["{{ .Values.registry.submodelRegistryBaseUrl }}"]
+        "submodelRegistries": ["{{ .Values.registry.submodelRegistryBaseUrl }}"]{{- if and .Values.registrySynchronization.auth.header.name .Values.registrySynchronization.auth.header.value }},{{ end }}
+        {{- end }}
+        {{- if and .Values.registrySynchronization.auth.header.name .Values.registrySynchronization.auth.header.value }}
+        "registrySynchronization": {
+          "auth": {
+            "header": {
+              "name": "{{ .Values.registrySynchronization.auth.header.name }}",
+              "value": "{{ .Values.registrySynchronization.auth.header.value }}"
+            }
+          }
+        }
         {{- end }}
       },
       "persistence": {

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -57,6 +57,12 @@ registry:
   # Base URL for the Submodel Registry (FA³ST Registry)
   submodelRegistryBaseUrl: "https://faaast-registry"
 
+registrySynchronization:
+  auth:
+    header:
+      name: ""
+      value: ""
+
 endpoints:
   - class: "de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.HttpEndpoint"
     port: 8080


### PR DESCRIPTION
- Adds optional Helm values to configure a static auth HTTP header for FAAAST Service registry synchronization requests registrySynchronization.auth.header.name/value

- Updates the  faaast-service ConfigMap template to inject this into core.registrySynchronization.auth.header in config.json when both values are set.
