### PR TITLE
feat: fa³st configure service.name

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,10 +3,10 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 0.2.5
+    version: 0.2.6
     repository: "file://../faaast-service"
   - name: faaast-registry
-    version: 0.2.3
+    version: 0.2.4
     repository: "file://../faaast-registry"
   - name: aas-basyx-v2-full
     version: 2.1.12
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.13
+version: 0.6.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-registry/Chart.yaml
+++ b/charts/faaast-registry/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-registry/templates/service.yaml
+++ b/charts/faaast-registry/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.server.port }}
       protocol: TCP
-      name: https
+      name: {{ .Values.service.name }}
   selector:
     app.kubernetes.io/name: {{ include (printf "%s.name" .Chart.Name) . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/faaast-registry/values.yaml
+++ b/charts/faaast-registry/values.yaml
@@ -8,6 +8,7 @@ image:
 service:
   type: ClusterIP
   port: 443
+  name: https
 
 fullnameOverride: faaast-registry
 

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/templates/service.yaml
+++ b/charts/faaast-service/templates/service.yaml
@@ -9,9 +9,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 8080
+      targetPort: {{ (index .Values.endpoints 0).port }}
       protocol: TCP
-      name: https
+      name: {{ .Values.service.name }}
   selector:
     app.kubernetes.io/name: {{ include (printf "%s.name" .Chart.Name) . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/faaast-service/values.yaml
+++ b/charts/faaast-service/values.yaml
@@ -8,6 +8,7 @@ image:
 service:
   type: ClusterIP
   port: 443
+  name: https
 
 fullnameOverride: faaast-service
 


### PR DESCRIPTION
## WHAT

Make (kubernetes) service name configurable in FA³ST (Service+Registry) as the port is configurable too.

## WHY

Configurability of only port is incomplete, only 443 is possible right now.

## FURTHER NOTES

no