### PR TITLE
feat: add normative text

### DIFF
--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -72,31 +72,18 @@
   </style>
 
 </head>
-<h1>
-  AsyncAPI specification for Events on the Asset Administration Shell
-</h1>
 <body>
 <p>
   <a href="./aas-repository/" class="button">Events emitted by <b>AAS Repositories</b></a>
-
-</p>
-<p>
-  <a>
-
-  </a>
 </p>
 <p>
   <a href="./submodel-repository/" class="button">Events emitted by <b>Submodel Repositories</b></a>
-
-</p>
-<p>
-  <a>
-
-  </a>
 </p>
 <p>
   <a href="./submodel-repository-submodelelement/" class="button"><b>SubmodelElement-level</b> Events emitted by <b>Submodel Repositories</b></a>
-
 </p>
+<div id="readme">
+<!-- README_CONTENT -->
+</div>
 </body>
 </html>

--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -7,6 +7,7 @@
   <style>
     body {
       margin: 0;
+      padding: 0 4mm;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background-color: #fff;
       color: #111;

--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -83,8 +83,8 @@
 <p>
   <a href="./submodel-repository-submodelelement/" class="button"><b>SubmodelElement-level</b> Events emitted by <b>Submodel Repositories</b></a>
 </p>
-<div id="readme">
+<p id="readme">
 <!-- README_CONTENT -->
-</div>
+</p>
 </body>
 </html>

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Move frontpage
         run: mv .github/resources/index.html .
 
+      - name: Inject README into frontpage
+        run: |
+          README_HTML=$(npx --yes marked specs/README.md | sed 's|./artifacts/|./specs/artifacts/|g')
+          README_HTML="${README_HTML//$'\n'/\\n}"
+          sed -i "s|<!-- README_CONTENT -->|$README_HTML|" index.html
+
       - name: Generating HTML for AAS document
         uses: asyncapi/cli@v3.2.0
         with:

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,92 +15,96 @@ to discover data updates.
 
 ## Message Semantics
 
-All messages in this specification conform to the CloudEvents 1.0 envelope format and carry a structured payload
-describing a state change in an AAS repository. Each message is classified by the resource type it concerns and the
-lifecycle event that triggered it. Providers MUST use the event type field to signal the nature of the change to the
-consumers allowing them to decide on processing it without inspecting the payload body.
+All messages in this specification conform to the CloudEvents 1.0 envelope format and carry a payload
+indicating a state change in an AAS repository. Each message is classified by the resource type it concerns and the
+lifecycle event that triggered it. Providers MUST use the payload's `type` field to signal the nature of the event to
+the consumers allowing them to decide on processing it without inspecting the rest of the payload.
 
 ### Asset Administration Shell Events
 
 #### AAS Element Created
 
-`io.admin-shell.events.v1.created` — Emitted when a new Asset Administration Shell is persisted in the repository for
-the first time. The payload body contains the full representation of the newly created shell, allowing consumers to
-immediately index or act on it without issuing a follow-up retrieval request. This event MUST be emitted exactly once
-per shell creation and MUST NOT be emitted for subsequent modifications to the same shell.
+`io.admin-shell.events.v1.created` — Emitted when a new Asset Administration Shell is persisted in the repository. If
+present, the `data` property contains the full representation of the newly created AAS, allowing consumers to
+immediately act on it without issuing a follow-up retrieval request. This event MUST be emitted exactly once
+per AAS creation and MUST NOT be emitted for subsequent modifications to the same AAS. The `dataschema` property
+can only reference the AAS metamodel element.
 
 #### AAS Element Updated
 
 `io.admin-shell.events.v1.updated` — Emitted when the metadata or structural composition of an existing Asset
 Administration Shell changes. Changes that trigger this event include modifications to the shell's administrative
-information, asset information, or the set of submodel references it holds. The payload body contains the updated shell
-representation in its entirety at the time the event was produced. Consumers SHOULD treat receipt of this event as an
-authoritative replacement for any previously held state of the shell identified by the same identifier.
+information, asset information, or the set of submodel references it holds. If present, the `data` property contains the
+updated element in its entirety after the change. Consumers SHOULD treat receipt of this event as an authoritative
+replacement for any previously held state of the element identified by the same identifier. The `dataschema` property
+can only reference elements with their own HTTP endpoint and schema, for example `asset-information` or `submodel-refs`.
 
 ### Submodel Events
 
 #### Submodel Created
 
-`io.admin-shell.events.v1.created` — Emitted when a new Submodel is persisted in the repository. The payload body
-contains the full Submodel representation, including its semantic identification and all submodel elements present at
-creation time. This event MUST be emitted exactly once when a Submodel is first created and MUST NOT be emitted for
-subsequent changes to that Submodel.
+`io.admin-shell.events.v1.created` — Emitted when a new Submodel is persisted in the repository. If present, the `data`
+property contains the full Submodel representation, including its semantic identification and all submodel elements
+present at creation time. This event MUST be emitted exactly once when a Submodel is first created and MUST NOT be
+emitted for subsequent changes to that Submodel. The `dataschema` property can only reference the Submodel metamodel
+element.
 
 #### Submodel Updated
 
 `io.admin-shell.events.v1.updated` — Emitted when the metadata of an existing Submodel changes. This event concerns
 structural or descriptive changes at the Submodel level itself — such as changes to its semantic identification,
-administrative information, or kind — and is distinct from value changes to individual submodel elements within it. The
-payload body contains the updated Submodel representation. Consumers SHOULD replace any previously held state of the
-identified Submodel upon receipt.
+administrative information, or kind — and is distinct from any changes to individual submodel elements within it. If
+present, the `data` property contains the updated Submodel representation. Consumers SHOULD treat receipt of this
+event as an authoritative replacement for any previously held state of the shell identified by the same identifier.
+The `dataschema` property can only reference the Submodel metamodel element as SubmodelElements are handled elsewhere.
 
 #### Submodel Deleted
 
-`io.admin-shell.events.v1.deleted` — Emitted when a Submodel is permanently removed from the repository. The payload
-body is absent; the identity of the deleted resource is conveyed through the source reference in the envelope. Consumers
+`io.admin-shell.events.v1.deleted` — Emitted when a Submodel is permanently removed from the repository. The AAS payload
+is absent; the identity of the deleted resource is conveyed through the `source` property in the envelope. Consumers
 MUST consider any locally cached state for the identified Submodel invalid upon receipt of this event.
 
 ### SubmodelElement Events
-
-#### Value Changed
-
-`io.admin-shell.events.v1.valueChanged` — Emitted when the value of a SubmodelElement changes while the element itself
-remains structurally unmodified. This event is specific to data elements that carry a value, such as properties or
-files. The payload body contains the SubmodelElement in its updated state. Consumers SHOULD use this event as the
-primary mechanism for tracking live data updates in an AAS deployment.
 
 #### SubmodelElement Created
 
 `io.admin-shell.events.v1.created` — Emitted when a new SubmodelElement is added to an existing Submodel. The source
 reference in the envelope identifies the containing element or Submodel into which the new element was inserted. The
-payload body contains the full representation of the newly created SubmodelElement. This event MUST be emitted exactly
+`data` property contains the full representation of the newly created SubmodelElement. This event MUST be emitted
+exactly
 once per element creation.
+
+#### Value Changed
+
+`io.admin-shell.events.v1.valueChanged` — Emitted when the value of a DataElement changes while the element itself
+remains structurally unmodified. If any other attribute changes, a SubmodelElement Updated event is emitted. If present,
+the `data` property contains the SubmodelElement in its updated state. Consumers SHOULD use this event as
+the primary mechanism for tracking live data updates in an AAS deployment.
 
 #### SubmodelElement Updated
 
 `io.admin-shell.events.v1.updated` — Emitted when the structure or metadata of an existing SubmodelElement changes in a
-way other than a pure value change. This includes changes to semantic identification, qualifiers, or category. The
-payload body contains the updated element representation. Consumers SHOULD replace any previously held state of the
-identified element upon receipt.
+way other than a pure value change. This includes changes to semantic identification, qualifiers, or category. If
+present, the `data` property contains the updated element representation. Consumers SHOULD replace any previously held
+state of the identified element upon receipt.
 
 #### SubmodelElement Deleted
 
-`io.admin-shell.events.v1.deleted` — Emitted when a SubmodelElement is removed from its containing Submodel or
-SubmodelElementCollection. The source reference in the envelope identifies the container from which the element was
-removed, not the element itself, because the element no longer exists at the time the event is produced. The payload
-body is absent. Consumers MUST invalidate any locally cached state for the deleted element upon receipt.
+`io.admin-shell.events.v1.deleted` — Emitted when a SubmodelElement is removed from its containing Submodel,
+SubmodelElementList or SubmodelElementCollection. The `source` property in the envelope identifies the deleted
+SubmodelElement. The SubmodelElement payload is absent from the event. Consumers MUST invalidate any locally
+cached state for the deleted element upon receipt.
 
 #### Operation Invoked
 
-`io.admin-shell.events.v1.invoked` — Emitted when an Operation SubmodelElement is invoked by a client. The payload body
-contains the Operation element including the input variables supplied by the invoking client. This event enables audit
-logging, orchestration, and side-effect processing by downstream consumers. Receipt of this event does not imply that
-execution has completed or succeeded.
+`io.admin-shell.events.v1.invoked` — Emitted when an Operation SubmodelElement is invoked by a client. If present, the
+`data` property contains the Operation element including the InputArguments and InoutputArguments supplied by the
+invoking client. Receipt of this event does not imply that the Operation has completed or succeeded.
 
 #### Operation Finished
 
-`io.admin-shell.events.v1.finished` — Emitted when an Operation invocation completes, regardless of whether it succeeded
-or failed. The payload body contains the inoutput arguments as they were modified during execution, along with the
-output arguments produced as the operation result. Consumers correlate this event with a preceding Operation Invoked
-event using the event identifier in the envelope. This event MUST be emitted exactly once per completed invocation.
+`io.admin-shell.events.v1.finished` — Emitted when an Operation completes, regardless of whether it succeeded
+or failed. If present, the `data` property contains the InoutputArguments and OutputArguments as produced as the
+operation result. Consumers correlate this event with a Operation using the `source` property in the envelope. This
+event MUST be emitted exactly once per completed Operation.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,11 +1,15 @@
 # Specification for Messaging with the Asset Administration Shell
 
 ## Introduction
-The aim of this specification is to define a messaging mechanism through which changes to asset administration shells (AASs), submodels and submodel-elements in an AAS repository can be communicated to interested data consumers in near real time.
 
-This specification complements the AAS REST API by introducing a publish-subscribe (pub-sub) mechanism. While the REST API is designed to fulfil the purpose of providing standardized, structured access to data, the pub-sub mechanism complements this by enabling real-time notifications to data consumers. Specifically, it ensures that consumers are immediately informed of any changes to the data in the AAS repository, thereby enhancing responsiveness and eliminating the need for frequent polling/scraping of the repository to discover data updates.
+The aim of this specification is to define a messaging mechanism through which events concerning resources from the
+Asset Administration Shell specification (IDTA-01001, IDTA-01002) can be communicated to interested data consumers.
 
-REST-type connections follow a request-response model. The client initiates communication by sending a request to the server, which then responds by sending back the requested data. This means that the client must actively poll the server to receive information. In contrast, publish-subscribe connections are event-driven. Clients subscribe to specific topics, and the broker automatically pushes updates to them whenever relevant data changes.
+This specification complements the AAS REST API by introducing a message payload for the events. While the REST
+API is designed to specify the synchronous retrieval and manipulation of data, the events enable notifications to data
+consumers. Specifically, it ensures that data consumers are immediately informed of any changes to the data in the AAS 
+repository, thereby enhancing responsiveness and eliminating the need for frequent polling/scraping of the repository 
+to discover data updates.
 
 ![MQTT Concept](./artifacts/aas-sync-mqtt-concept.png)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,6 +1,6 @@
-## Specification for Messaging with the Asset Administration Shell
+# Specification for Messaging with the Asset Administration Shell
 
-# Introduction
+## Introduction
 The aim of this specification is to define a messaging mechanism through which changes to asset administration shells (AASs), submodels and submodel-elements in an AAS repository can be communicated to interested data consumers in near real time.
 
 This specification complements the AAS REST API by introducing a publish-subscribe (pub-sub) mechanism. While the REST API is designed to fulfil the purpose of providing standardized, structured access to data, the pub-sub mechanism complements this by enabling real-time notifications to data consumers. Specifically, it ensures that consumers are immediately informed of any changes to the data in the AAS repository, thereby enhancing responsiveness and eliminating the need for frequent polling/scraping of the repository to discover data updates.

--- a/specs/README.md
+++ b/specs/README.md
@@ -7,11 +7,100 @@ Asset Administration Shell specification (IDTA-01001, IDTA-01002) can be communi
 
 This specification complements the AAS REST API by introducing a message payload for the events. While the REST
 API is designed to specify the synchronous retrieval and manipulation of data, the events enable notifications to data
-consumers. Specifically, it ensures that data consumers are immediately informed of any changes to the data in the AAS 
-repository, thereby enhancing responsiveness and eliminating the need for frequent polling/scraping of the repository 
+consumers. Specifically, it ensures that data consumers are immediately informed of any changes to the data in the AAS
+repository, thereby enhancing responsiveness and eliminating the need for frequent polling/scraping of the repository
 to discover data updates.
 
 ![MQTT Concept](./artifacts/aas-sync-mqtt-concept.png)
 
-### Message Semantics
+## Message Semantics
+
+All messages in this specification conform to the CloudEvents 1.0 envelope format and carry a structured payload
+describing a state change in an AAS repository. Each message is classified by the resource type it concerns and the
+lifecycle event that triggered it. Providers MUST use the event type field to signal the nature of the change to the
+consumers allowing them to decide on processing it without inspecting the payload body.
+
+### Asset Administration Shell Events
+
+#### AAS Element Created
+
+`io.admin-shell.events.v1.created` — Emitted when a new Asset Administration Shell is persisted in the repository for
+the first time. The payload body contains the full representation of the newly created shell, allowing consumers to
+immediately index or act on it without issuing a follow-up retrieval request. This event MUST be emitted exactly once
+per shell creation and MUST NOT be emitted for subsequent modifications to the same shell.
+
+#### AAS Element Updated
+
+`io.admin-shell.events.v1.updated` — Emitted when the metadata or structural composition of an existing Asset
+Administration Shell changes. Changes that trigger this event include modifications to the shell's administrative
+information, asset information, or the set of submodel references it holds. The payload body contains the updated shell
+representation in its entirety at the time the event was produced. Consumers SHOULD treat receipt of this event as an
+authoritative replacement for any previously held state of the shell identified by the same identifier.
+
+### Submodel Events
+
+#### Submodel Created
+
+`io.admin-shell.events.v1.created` — Emitted when a new Submodel is persisted in the repository. The payload body
+contains the full Submodel representation, including its semantic identification and all submodel elements present at
+creation time. This event MUST be emitted exactly once when a Submodel is first created and MUST NOT be emitted for
+subsequent changes to that Submodel.
+
+#### Submodel Updated
+
+`io.admin-shell.events.v1.updated` — Emitted when the metadata of an existing Submodel changes. This event concerns
+structural or descriptive changes at the Submodel level itself — such as changes to its semantic identification,
+administrative information, or kind — and is distinct from value changes to individual submodel elements within it. The
+payload body contains the updated Submodel representation. Consumers SHOULD replace any previously held state of the
+identified Submodel upon receipt.
+
+#### Submodel Deleted
+
+`io.admin-shell.events.v1.deleted` — Emitted when a Submodel is permanently removed from the repository. The payload
+body is absent; the identity of the deleted resource is conveyed through the source reference in the envelope. Consumers
+MUST consider any locally cached state for the identified Submodel invalid upon receipt of this event.
+
+### SubmodelElement Events
+
+#### Value Changed
+
+`io.admin-shell.events.v1.valueChanged` — Emitted when the value of a SubmodelElement changes while the element itself
+remains structurally unmodified. This event is specific to data elements that carry a value, such as properties or
+files. The payload body contains the SubmodelElement in its updated state. Consumers SHOULD use this event as the
+primary mechanism for tracking live data updates in an AAS deployment.
+
+#### SubmodelElement Created
+
+`io.admin-shell.events.v1.created` — Emitted when a new SubmodelElement is added to an existing Submodel. The source
+reference in the envelope identifies the containing element or Submodel into which the new element was inserted. The
+payload body contains the full representation of the newly created SubmodelElement. This event MUST be emitted exactly
+once per element creation.
+
+#### SubmodelElement Updated
+
+`io.admin-shell.events.v1.updated` — Emitted when the structure or metadata of an existing SubmodelElement changes in a
+way other than a pure value change. This includes changes to semantic identification, qualifiers, or category. The
+payload body contains the updated element representation. Consumers SHOULD replace any previously held state of the
+identified element upon receipt.
+
+#### SubmodelElement Deleted
+
+`io.admin-shell.events.v1.deleted` — Emitted when a SubmodelElement is removed from its containing Submodel or
+SubmodelElementCollection. The source reference in the envelope identifies the container from which the element was
+removed, not the element itself, because the element no longer exists at the time the event is produced. The payload
+body is absent. Consumers MUST invalidate any locally cached state for the deleted element upon receipt.
+
+#### Operation Invoked
+
+`io.admin-shell.events.v1.invoked` — Emitted when an Operation SubmodelElement is invoked by a client. The payload body
+contains the Operation element including the input variables supplied by the invoking client. This event enables audit
+logging, orchestration, and side-effect processing by downstream consumers. Receipt of this event does not imply that
+execution has completed or succeeded.
+
+#### Operation Finished
+
+`io.admin-shell.events.v1.finished` — Emitted when an Operation invocation completes, regardless of whether it succeeded
+or failed. The payload body contains the inoutput arguments as they were modified during execution, along with the
+output arguments produced as the operation result. Consumers correlate this event with a preceding Operation Invoked
+event using the event identifier in the envelope. This event MUST be emitted exactly once per completed invocation.
 

--- a/specs/asyncapi_spec_aas.yaml
+++ b/specs/asyncapi_spec_aas.yaml
@@ -44,12 +44,67 @@ components:
       summary: Emitted when an AAS element is updated
       payload:
         $ref: '#/components/schemas/elementUpdatedEvent'
+      examples:
+        - name: AAS element updated
+          payload:
+            specversion: '1.0'
+            id: 358c02f2-3a11-4836-971b-43a05550bf97
+            source: 'https://providercorp.com/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9hYXMv'
+            type: io.admin-shell.events.v1.updated
+            datacontenttype: application/json
+            dataschema: 'https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/aas.json#/definitions/AssetAdministrationShell'
+            time: '2024-11-26T10:46:33.2171298+01:00'
+            data:
+              id: 'https://example.com/aas/robot-arm-001'
+              modelType: AssetAdministrationShell
+              idShort: RobotArm001
+              description:
+                - language: en
+                  text: Asset Administration Shell for industrial robot arm
+              assetInformation:
+                assetKind: Instance
+                globalAssetId: 'urn:example:robot-arm:serial:12345'
+              submodels:
+                - type: ModelReference
+                  keys:
+                    - type: Submodel
+                      value: 'https://example.com/submodels/nameplate-001'
     elementCreated:
       name: AASelementCreated
       title: AAS Element Create message
       summary: Emitted when an AAS element is created
       payload:
         $ref: '#/components/schemas/elementCreatedEvent'
+      examples:
+        - name: AAS element created
+          payload:
+            specversion: '1.0'
+            id: ecbd132e-d834-4528-bb30-6790104ca474
+            source: 'https://mycorp.com/aas-repo/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9hYXMv'
+            type: io.admin-shell.events.v1.created
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/AssetAdministrationShell'
+            time: '2024-11-26T10:44:11.9367113+01:00'
+            data:
+              id: 'https://example.com/aas/pump-unit-007'
+              modelType: AssetAdministrationShell
+              idShort: PumpUnit007
+              description:
+                - language: en
+                  text: Asset Administration Shell for pump unit 007
+                - language: de
+                  text: Verwaltungsschale für Pumpeinheit 007
+              assetInformation:
+                assetKind: Instance
+                globalAssetId: 'urn:example:pump:serial:PMP-007'
+                specificAssetIds:
+                  - name: serialNumber
+                    value: PMP-007
+              submodels:
+                - type: ModelReference
+                  keys:
+                    - type: Submodel
+                      value: 'https://example.com/submodels/technical-data-007'
   parameters:
     aasid:
       description: The Id of the asset administration shell.

--- a/specs/asyncapi_spec_submodel.yaml
+++ b/specs/asyncapi_spec_submodel.yaml
@@ -54,18 +54,89 @@ components:
       summary: Emitted when the metadata of a submodel is updated
       payload:
         $ref: '#/components/schemas/updatedEvent'
+      examples:
+        - name: Submodel updated
+          payload:
+            specversion: '1.0'
+            id: 358c02f2-3a11-4836-971b-43a05550bf97
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvbmFtZXBsYXRlLTAwMQ=='
+            type: io.admin-shell.events.v1.updated
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Submodel'
+            time: '2024-11-26T10:46:33.2171298+01:00'
+            semanticid: '0173-1#02-AAA119#002'
+            data:
+              id: 'https://example.com/submodels/nameplate-001'
+              modelType: Submodel
+              idShort: Nameplate
+              kind: Instance
+              semanticId:
+                type: ExternalReference
+                keys:
+                  - type: GlobalReference
+                    value: '0173-1#01-AAA111#002'
+              submodelElements:
+                - idShort: ManufacturerName
+                  modelType: Property
+                  valueType: xs:string
+                  value: Example Corp GmbH
+                - idShort: SerialNumber
+                  modelType: Property
+                  valueType: xs:string
+                  value: SN-20241126-001
     created:
       name: SubmodelCreated
       title: Submodel Create message
       summary: Emitted when a submodel is created
       payload:
         $ref: '#/components/schemas/createdEvent'
+      examples:
+        - name: Submodel created
+          payload:
+            specversion: '1.0'
+            id: ecbd132e-d834-4528-bb30-6790104ca474
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvdGVjaC1kYXRhLTAwMQ=='
+            type: io.admin-shell.events.v1.created
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Submodel'
+            time: '2024-11-26T10:44:11.9367113+01:00'
+            semanticid: '0173-1#02-AAA120#003'
+            data:
+              id: 'https://example.com/submodels/tech-data-001'
+              modelType: Submodel
+              idShort: TechnicalData
+              kind: Instance
+              semanticId:
+                type: ExternalReference
+                keys:
+                  - type: GlobalReference
+                    value: '0173-1#01-AFZ615#016'
+              submodelElements:
+                - idShort: MaxRotationSpeed
+                  modelType: Property
+                  valueType: xs:int
+                  value: '5000'
+                  semanticId:
+                    type: ExternalReference
+                    keys:
+                      - type: GlobalReference
+                        value: '0173-1#02-ABH978#001'
     deleted:
       name: SubmodelDeleted
       title: Submodel Delete message
       summary: Emitted when a submodel is deleted
       payload:
         $ref: '#/components/schemas/deletedEvent'
+      examples:
+        - name: Submodel deleted
+          payload:
+            specversion: '1.0'
+            id: 7f3c1a2b-9e44-4c31-bc01-2890abc45678
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb2Jzb2xldGUtMDIz'
+            type: io.admin-shell.events.v1.deleted
+            datacontenttype: application/json
+            time: '2024-11-26T11:02:50.1234567+01:00'
+            semanticid: '0173-1#02-AAA119#002'
   parameters:
     submodelid:
       description: The Id of the submodel in the Asset Administration Shell with aasId.

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -160,7 +160,7 @@ components:
           payload:
             specversion: '1.0'
             id: 9a1b2c3d-4e5f-6789-abcd-ef0123456789
-            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb3BlcmF0aW9uYWwtZGF0YQ=='
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb3BlcmF0aW9uYWwtZGF0YQ==/submodel-elements/ManufacturerName'
             type: io.admin-shell.events.v1.deleted
             datacontenttype: application/json
             time: '2025-09-25T13:37:12.3456789+01:00'
@@ -586,7 +586,6 @@ components:
         $ref: https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/aas.json#/definitions/OperationVariable
       examples:
         - '[ {"idShort":"MyInoutputArgument", "value": 100} ]'
-        - '[{"note": "original value"}]'
       description:
         The supplied inoutput variable(s) for an operation invocation.
       type: array
@@ -596,7 +595,6 @@ components:
         $ref: https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/aas.json#/definitions/OperationVariable
       examples:
         - '[ {"idShort":"MyOperationOutput", "value": 123456} ]'
-        - '[{"note": "new value"}]'
         - $ref: https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/examples/generated/OperationVariable/maximal.json#/submodels/0/submodelElements/0
       description:
         The output variable(s) as the operation result.

--- a/specs/asyncapi_spec_submodelelement.yaml
+++ b/specs/asyncapi_spec_submodelelement.yaml
@@ -79,36 +79,153 @@ components:
       summary: Triggered when the value of an element is updated
       payload:
         $ref: '#/components/schemas/valueChangedEvent'
+      examples:
+        - name: Property value changed
+          payload:
+            specversion: '1.0'
+            id: 358c02f2-3a11-4836-971b-43a05550bf97
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb3BlcmF0aW9uYWwtZGF0YQ==/submodel-elements/Sensors.TemperatureSensor01.CurrentTemperature'
+            type: io.admin-shell.events.v1.valueChanged
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property'
+            time: '2025-09-25T13:37:12.3456789+01:00'
+            semanticid: '0173-1#02-AAA119#002'
+            data:
+              idShort: CurrentTemperature
+              modelType: Property
+              valueType: xs:float
+              value: '72.4'
+              semanticId:
+                type: ExternalReference
+                keys:
+                  - type: GlobalReference
+                    value: '0173-1#02-AAA119#002'
     elementCreated:
-      name: SubmodelElementUpdated
+      name: SubmodelElementCreated
       title: SubmodelElement Create message
       summary: Triggered when an element is created
       payload:
         $ref: '#/components/schemas/elementCreatedEvent'
+      examples:
+        - name: SubmodelElement created
+          payload:
+            specversion: '1.0'
+            id: ecbd132e-d834-4528-bb30-6790104ca474
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb3BlcmF0aW9uYWwtZGF0YQ==/submodel-elements/Sensors'
+            type: io.admin-shell.events.v1.created
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property'
+            time: '2025-09-25T13:37:12.3456789+01:00'
+            semanticid: '0173-1#02-AAA119#002'
+            data:
+              idShort: PressureSensor02
+              modelType: Property
+              valueType: xs:float
+              value: '1.013'
+              semanticId:
+                type: ExternalReference
+                keys:
+                  - type: GlobalReference
+                    value: '0173-1#02-AAZ337#001'
     elementUpdated:
       name: SubmodelElementUpdated
       title: SubmodelElement Update message
       summary: Triggered when an element is updated
       payload:
         $ref: '#/components/schemas/elementUpdatedEvent'
+      examples:
+        - name: SubmodelElement updated
+          payload:
+            specversion: '1.0'
+            id: 7f3c1a2b-9e44-4c31-bc01-2890abc45678
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvbmFtZXBsYXRl/submodel-elements/ManufacturerName'
+            type: io.admin-shell.events.v1.updated
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Property'
+            time: '2025-09-25T13:37:12.3456789+01:00'
+            semanticid: '0173-1#02-AAO677#001'
+            data:
+              idShort: ManufacturerName
+              modelType: Property
+              valueType: xs:string
+              value: Example Corp GmbH (updated)
     elementDeleted:
-      name: SubmodelElementUpdated
+      name: SubmodelElementDeleted
       title: SubmodelElement Delete message
       summary: Triggered when an element is deleted
       payload:
         $ref: '#/components/schemas/elementDeletedEvent'
+      examples:
+        - name: SubmodelElement deleted
+          payload:
+            specversion: '1.0'
+            id: 9a1b2c3d-4e5f-6789-abcd-ef0123456789
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvb3BlcmF0aW9uYWwtZGF0YQ=='
+            type: io.admin-shell.events.v1.deleted
+            datacontenttype: application/json
+            time: '2025-09-25T13:37:12.3456789+01:00'
+            semanticid: '0173-1#02-AAA119#002'
     operationInvoked:
       name: OperationInvoked
       title: Operation Invoke message
       summary: Triggered when an operation is invoked
       payload:
         $ref: '#/components/schemas/operationInvokedEvent'
+      examples:
+        - name: Operation invoked
+          payload:
+            specversion: '1.0'
+            id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvY29udHJvbA==/submodel-elements/StartMotor'
+            type: io.admin-shell.events.v1.invoked
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/Operation'
+            time: '2025-09-25T13:37:12.3456789+01:00'
+            semanticid: '0173-1#02-ABI006#001'
+            data:
+              idShort: StartMotor
+              modelType: Operation
+              inputVariables:
+                - value:
+                    idShort: TargetSpeed
+                    modelType: Property
+                    valueType: xs:int
+                    value: '3000'
+              outputVariables:
+                - value:
+                    idShort: OperationHandle
+                    modelType: Property
+                    valueType: xs:string
     operationFinished:
       name: OperationFinished
       title: Operation Finish message
       summary: Triggered when an operation is finished
       payload:
         $ref: '#/components/schemas/operationFinishedEvent'
+      examples:
+        - name: Operation finished successfully
+          payload:
+            specversion: '1.0'
+            id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+            source: 'https://providercorp.com/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJtb2RlbHMvY29udHJvbA==/submodel-elements/StartMotor'
+            type: io.admin-shell.events.v1.finished
+            datacontenttype: application/json
+            dataschema: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#/components/schemas/OperationVariable'
+            time: '2025-09-25T13:37:15.7654321+01:00'
+            semanticid: '0173-1#02-ABI006#001'
+            data:
+              inoutputArguments:
+                - value:
+                    idShort: TargetSpeed
+                    modelType: Property
+                    valueType: xs:int
+                    value: '3000'
+              outputArguments:
+                - value:
+                    idShort: ActualSpeed
+                    modelType: Property
+                    valueType: xs:int
+                    value: '2998'
   schemas:
     valueChangedEvent:
       properties:
@@ -466,7 +583,7 @@ components:
     inoutputArguments:
       items:
         description: List of OperationVariables declared as inoutputArguments.
-        type: string
+        $ref: https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/aas.json#/definitions/OperationVariable
       examples:
         - '[ {"idShort":"MyInoutputArgument", "value": 100} ]'
         - '[{"note": "original value"}]'
@@ -476,7 +593,6 @@ components:
     outputArguments:
       items:
         description: List of OperationVariables declared as outputArguments.
-        type: string
         $ref: https://raw.githubusercontent.com/admin-shell-io/aas-specs-metamodel/refs/heads/master/schemas/json/aas.json#/definitions/OperationVariable
       examples:
         - '[ {"idShort":"MyOperationOutput", "value": 123456} ]'


### PR DESCRIPTION
## WHAT

Add inital spec text on event semantics

## WHY

Provide human-readable norms on server behavior to support implementation

## FURTHER NOTES

Deployment preview: https://arnoweiss.github.io/async-aas-helm/

Closes #122
Superseeds #131