### PR TITLE
fix: correct DTR discovery integration and basyx client auth

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.15
+version: 0.6.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/config/basyx-realm.json
+++ b/charts/async-aas-helm/config/basyx-realm.json
@@ -9,7 +9,7 @@
   "roles": {
     "realm": [
       { "name": "user", "description": "default user" },
-      { "name": "admin", "description": "realm administrator" }
+      { "name": "admin", "description": "application administrator" }
     ]
   },
   "users": [
@@ -38,6 +38,7 @@
       "secret": "<path:factory-x-ci-cd/data/async-aas#basyx-clientsecret>",
       "publicClient": false,
       "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
       "standardFlowEnabled": false,
       "directAccessGrantsEnabled": false,
       "redirectUris": [
@@ -45,7 +46,8 @@
       ],
       "webOrigins": [
         "*"
-      ]
+      ],
+      "serviceAccountRealmRoles": ["admin"]
     }
   ]
 }

--- a/charts/async-aas-helm/config/basyx-realm.json
+++ b/charts/async-aas-helm/config/basyx-realm.json
@@ -29,6 +29,12 @@
         }
       ],
       "realmRoles": ["admin"]
+    },
+    {
+      "username": "service-account-<path:factory-x-ci-cd/data/async-aas#basyx-clientid>",
+      "enabled": true,
+      "serviceAccountClientId": "<path:factory-x-ci-cd/data/async-aas#basyx-clientid>",
+      "realmRoles": ["admin"]
     }
   ],
   "clients": [
@@ -46,8 +52,7 @@
       ],
       "webOrigins": [
         "*"
-      ],
-      "serviceAccountRealmRoles": ["admin"]
+      ]
     }
   ]
 }

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -488,8 +488,8 @@ aas-basyx-v2-full:
       basyx.aasdiscoveryservice.name=digital-twin-registry
       basyx.cors.allowed-methods=GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD
       basyx.cors.allowed-origins=*
-      basyx.feature.aasregistry.discoveryintegration.enabled=true
-      basyx.feature.aasregistry.discoveryintegration.baseUrl=http://localhost:8081
+      basyx.aasregistry.feature.discoveryintegration.enabled=true
+      basyx.aasregistry.feature.discoveryintegration.baseUrl=http://localhost:8081
       basyx.endpoints.web.exposure.include=health,metrics,mappings
       server.port=8081
       spring.profiles.active=logEvents,MongoDB


### PR DESCRIPTION
- Fix property prefix `basyx.feature.aasregistry.discoveryintegration.*` → `basyx.aasregistry.feature.discoveryintegration.*` so the `DiscoveryIntegrationAasRegistry` decorator is instantiated and registry→discovery sync works
- Enable `authorizationServicesEnabled` and assign `admin` realm role to the basyx service account client in `basyx-realm.json`