### PR TITLE
feat: add additional client credential access rules

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.16
+version: 0.6.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/config/basyx-realm.json
+++ b/charts/async-aas-helm/config/basyx-realm.json
@@ -9,7 +9,8 @@
   "roles": {
     "realm": [
       { "name": "user", "description": "default user" },
-      { "name": "admin", "description": "application administrator" }
+      { "name": "admin", "description": "application administrator" },
+      { "name": "basyx-aas-reader", "description": "read access to all AAS shells" }
     ]
   },
   "users": [
@@ -45,6 +46,21 @@
       "publicClient": false,
       "serviceAccountsEnabled": true,
       "authorizationServicesEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "*"
+      ]
+    },
+    {
+      "clientId": "<path:factory-x-ci-cd/data/async-aas#basyx-reader-clientid>",
+      "enabled": true,
+      "secret": "<path:factory-x-ci-cd/data/async-aas#basyx-reader-clientsecret>",
+      "publicClient": false,
+      "serviceAccountsEnabled": true,
       "standardFlowEnabled": false,
       "directAccessGrantsEnabled": false,
       "redirectUris": [

--- a/charts/async-aas-helm/config/fa3st-realm.json
+++ b/charts/async-aas-helm/config/fa3st-realm.json
@@ -46,6 +46,21 @@
             "webOrigins": [
                 "*"
             ]
+        },
+        {
+            "clientId": "<path:factory-x-ci-cd/data/async-aas#fa3st-r-all-two-clientid>",
+            "enabled": true,
+            "secret": "<path:factory-x-ci-cd/data/async-aas#fa3st-r-all-two-clientsecret>",
+            "publicClient": false,
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "redirectUris": [
+                "*"
+            ],
+            "webOrigins": [
+                "*"
+            ]
         }
     ]
 }

--- a/charts/async-aas-helm/config/rabbitmq-realm.json
+++ b/charts/async-aas-helm/config/rabbitmq-realm.json
@@ -40,6 +40,41 @@
             "optionalClientScopes": []
         },
         {
+            "clientId": "<path:factory-x-ci-cd/data/async-aas#keycloak-rabbitmq-mqtt-reader-clientid>",
+            "enabled": true,
+            "protocol": "openid-connect",
+            "clientAuthenticatorType": "client-secret",
+            "secret": "<path:factory-x-ci-cd/data/async-aas#keycloak-rabbitmq-mqtt-reader-clientsecret>",
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "publicClient": false,
+            "redirectUris": [
+                "*"
+            ],
+            "webOrigins": [
+                "*"
+            ],
+            "protocolMappers": [
+                {
+                    "name": "aud",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "included.client.audience": "rabbitmq",
+                        "id.token.claim": "false",
+                        "access.token.claim": "true",
+                        "userinfo.token.claim": "false"
+                    }
+                }
+            ],
+            "defaultClientScopes": [
+                "rabbitmq.read:*/*/*"
+            ],
+            "optionalClientScopes": []
+        },
+        {
             "clientId": "rabbitmq",
             "name": "",
             "description": "",

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -124,6 +124,20 @@ faaast-service:
                         {"$strVal": "<path:factory-x-ci-cd/data/async-aas#fa3st-rwx-nameplate-clientid>"}
                       ]
                     }
+                  },
+                  {
+                    "ACL": {
+                      "ATTRIBUTES": [{"CLAIM": "client_id"}],
+                      "RIGHTS": ["READ"],
+                      "ACCESS": "ALLOW"
+                    },
+                    "OBJECTS": [{"ROUTE": "*"}],
+                    "FORMULA": {
+                      "$eq": [
+                        {"$attribute": {"CLAIM": "client_id"}},
+                        {"$strVal": "<path:factory-x-ci-cd/data/async-aas#fa3st-r-all-two-clientid>"}
+                      ]
+                    }
                   }
                 ]
               }
@@ -327,6 +341,14 @@ aas-basyx-v2-full:
               "@type": "submodel",
               "submodelIds": "*",
               "submodelElementIdShortPaths": "*"
+            }
+          },
+          {
+            "role": "basyx-aas-reader",
+            "action": "READ",
+            "targetInformation": {
+              "@type": "aas",
+              "aasIds": "*"
             }
           },
           {


### PR DESCRIPTION
This PR extends the client-credential-based access setup across the async AAS stack.

Changes:
- add a new read client to the `fa3st` realm
- add a matching FAAAST read ACL rule in `values.yaml`
- add a new `basyx-aas-reader` realm role in the `basyx` realm
- add a new `basyx` client for that role
- add a matching BaSyx RBAC rule for reading all AAS shells
- add a new read-only MQTT client to the `rabbitmq` realm

## Files changed

- `charts/async-aas-helm/values.yaml`
- `charts/async-aas-helm/config/fa3st-realm.json`
- `charts/async-aas-helm/config/basyx-realm.json`
- `charts/async-aas-helm/config/rabbitmq-realm.json`

## Verification

Verified locally before removing the local-only test scaffolding:
- new FAAAST client was accepted and returned `200 OK`
- new BaSyx client with the new role returned `200` on `/shells`
- new RabbitMQ client successfully obtained a token

Local verification was done on a `kind` cluster with the umbrella chart deployed into the `async-aas` namespace.

Infrastructure steps:
- created a local `kind` cluster
- ran `helm dependency update charts/async-aas-helm`
- deployed the chart locally
- used `kubectl port-forward` to expose local services

Local endpoints used during verification:
- Keycloak: `http://127.0.0.1:18081`
- FAAAST Service: `http://127.0.0.1:18080`
- BaSyx AAS Environment: `http://127.0.0.1:18082`
- BaSyx Digital Twin Registry: `http://127.0.0.1:18083`
- RabbitMQ UI: `http://127.0.0.1:18085`

Verification approach:
- requested client-credentials tokens from the local Keycloak realms
- called FAAAST with the new FAAAST client and confirmed a `200 OK`
- called BaSyx with the new BaSyx client and new role and confirmed a `200` on `/shells`
- requested a token for the new RabbitMQ client and confirmed token issuance worked
- also checked unauthenticated behavior to confirm the APIs were actually protected

Representative commands used:

```bash
kubectl port-forward -n async-aas svc/basyx-keycloak 18081:80
kubectl port-forward -n async-aas svc/faaast-service 18080:443
kubectl port-forward -n async-aas svc/async-aas-aas-environment 18082:8081
```

```bash
TOKEN=$(curl -fsS -X POST 'http://127.0.0.1:18081/realms/fa3st/protocol/openid-connect/token' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  --data 'grant_type=client_credentials&client_id=fa3st-r-all-two-local&client_secret=fa3st-r-all-two-local-secret' \
  | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')

curl -i 'http://127.0.0.1:18080/api/v3.0/description' \
  -H "Authorization: Bearer $TOKEN"
```

```bash
kubectl run basyx-new-client-check --rm -i --restart=Never -n async-aas \
  --image=curlimages/curl:8.12.1 \
  -- sh -lc 'TOKEN=$(curl -fsS -X POST http://basyx-keycloak/realms/basyx/protocol/openid-connect/token -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=client_credentials&client_id=basyx-reader-local-client&client_secret=basyx-reader-local-secret" | sed -n "s/.*\"access_token\":\"\([^\"]*\)\".*/\1/p"); curl -i http://async-aas-aas-environment:8081/shells -H "Authorization: Bearer $TOKEN"'
```

## Notes

This PR only keeps the actual [ticket](https://factory-x.atlassian.net/browse/TP4A-174) changes.
The local-only `kind` testing files and local realm variants were removed from the branch.
