### PR TITLE
fix(basyx): point registry integration to DTR

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.17
+version: 0.6.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -257,7 +257,7 @@ aas-basyx-v2-full:
 
       basyx.cors.allowed-origins=*
       basyx.cors.allowed-methods=GET,POST,PATCH,DELETE,PUT,OPTIONS,HEAD
-      basyx.aasrepository.feature.registryintegration=https://<path:factory-x-ci-cd/data/async-aas#basyx-reg-url>
+      basyx.aasrepository.feature.registryintegration=https://<path:factory-x-ci-cd/data/async-aas#basyx-dtr-url>
       basyx.externalurl=https://<path:factory-x-ci-cd/data/async-aas#basyx-env-url>
       spring.servlet.multipart.max-file-size=128MB
       spring.servlet.multipart.max-request-size=128MB


### PR DESCRIPTION
## Summary
- Change `basyx.aasrepository.feature.registryintegration` to use `basyx-dtr-url` instead of `basyx-reg-url`
- Bump chart version to 0.6.18