### PR TITLE
added http rest examples to spec

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -101,6 +101,20 @@ The `dataschema` property can only reference the AAS metamodel element.
 **HTTP REST Example:**
 ```REST
 POST /shells
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+   "id":"aas-id",
+   "idShort":"aas-short-id",
+   "assetInformation":{
+      "assetKind":"Instance",
+      "globalAssetId":"asset-id"
+   }
+}
 ```
 
 **The following interface operations will trigger this event:**
@@ -148,7 +162,18 @@ The `dataschema` property can only reference elements with their own HTTP endpoi
 
 **HTTP REST Example:**
 ```REST
-PATCH /shells/{id}
+PUT /shells/{aas-id-base64}/asset-information
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "assetKind": "Instance",
+  "globalAssetId": "new-asset-id"
+}
+
 ```
 
 **The following interface operations will trigger this event:**
@@ -232,6 +257,18 @@ The `dataschema` property can only reference the SM metamodel element.
 **HTTP REST Example:**
 ```REST
 POST /submodels
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "id": "sm-id",
+  "idShort": "sm-id-short",
+  "submodelElements": []
+}
+
 ```
 
 **The following interface operations will trigger this event:**
@@ -267,7 +304,19 @@ The `dataschema` property can only reference the SM metamodel element as SMEs ar
 
 **HTTP REST Example:**
 ```REST
-PATCH /submodels/{id}
+PUT /submodels/{sm-id-base64}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "id": "sm-id",
+  "idShort": "new-sm-id-short",
+  "submodelElements": []
+}
+
 ```
 
 **The following interface operations will trigger this event:**
@@ -312,7 +361,11 @@ Consumers MUST consider any locally cached state for the identified SM invalid u
 
 **HTTP REST Example:**
 ```REST
-DELETE /submodels/{id}
+DELETE /submodels/{sm-id-base64}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
 ```
 
 **The following interface operations will trigger this event:**
@@ -348,7 +401,19 @@ This event MUST be triggered exactly once per element creation.
 
 **HTTP REST Example:**
 ```REST
-POST /submodels/{id}/submodelElements
+POST /submodels/{sm-id-base64}/submodelElements
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "idShort": "test-property",
+  "modelType": "Property",
+  "valueType": "xs:double",
+  "value": "25.0"
+}
 ```
 
 **The following interface operations will trigger this event:**
@@ -392,8 +457,14 @@ Consumers SHOULD use this event as the primary mechanism for tracking live data 
 
 **HTTP REST Example:**
 ```REST
-PATCH /submodelElements/power/value
-value = 10
+PATCH /submodels/{sm-id-base64}/submodel-elements/{sme}/value
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+10.0
 ```
 
 **The following interface operations will trigger this event:**
@@ -437,9 +508,18 @@ If present, the `data` property contains the updated element representation. Con
 
 **HTTP REST Example:**
 ```REST
-PATCH /submodelElements/{id}
+PUT /submodels/{sm-id-base64}/submodel-elements/{sme}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body: 
 {
-  "idShort": "newName"
+  "idShort": "new-test-property",
+  "modelType": "Property",
+  "valueType": "xs:double",
+  "value": "25.0"
 }
 ```
 
@@ -465,7 +545,11 @@ Consumers MUST invalidate any locally cached state for the deleted element upon 
 
 **HTTP REST Example:**
 ```REST
-DELETE /submodelElements/{id}
+DELETE /submodels/{sm-id-base64}/submodel-elements/{sme}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
 ```
 
 **The following interface operations will trigger this event:**

--- a/specs/README.md
+++ b/specs/README.md
@@ -98,25 +98,6 @@ If present, the `data` property contains the full representation of the newly cr
 This event MUST be triggered exactly once per AAS creation and MUST NOT be triggered for subsequent modifications to the same AAS. 
 The `dataschema` property can only reference the AAS metamodel element.
 
-**HTTP REST Example:**
-```REST
-POST /shells
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-
-Body:
-{
-   "id":"aas-id",
-   "idShort":"aas-short-id",
-   "assetInformation":{
-      "assetKind":"Instance",
-      "globalAssetId":"asset-id"
-   }
-}
-```
-
 **The following interface operations will trigger this event:**
 
 - `PostAssetAdministrationShell`
@@ -151,6 +132,24 @@ Body:
 
 _("*" indicates a mandatory parameter)_
 
+**HTTP REST Example:**
+```REST
+POST /shells
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+   "id":"aas-id",
+   "idShort":"aas-short-id",
+   "assetInformation":{
+      "assetKind":"Instance",
+      "globalAssetId":"asset-id"
+   }
+}
+```
 
 ### AAS Element Updated
 
@@ -159,22 +158,6 @@ Changes that trigger this event include modifications to the AAS's administrativ
 If present, the `data` property contains the updated element in its entirety after the change. 
 Consumers SHOULD treat receipt of this event as an authoritative replacement for any previously held state of the element identified by the same identifier. 
 The `dataschema` property can only reference elements with their own HTTP endpoint and schema, for example `asset-information` or `submodel-refs`.
-
-**HTTP REST Example:**
-```REST
-PUT /shells/{aas-id-base64}/asset-information
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-
-Body:
-{
-  "assetKind": "Instance",
-  "globalAssetId": "new-asset-id"
-}
-
-```
 
 **The following interface operations will trigger this event:**
 
@@ -197,7 +180,6 @@ Body:
     |----------|----------|
     | Asset Administration Shell object*  | Status code*   |
     |   | 	Replaced Asset Administration Shell   |
-
 
 - `PutAssetInformation`
     
@@ -240,10 +222,24 @@ Body:
     |----------|----------|
     | The unique ID of the Submodel for the reference to be deleted*  | Status code*   |
 
-
 _("*" indicates a mandatory parameter)_
 
 <!-- If submodel is newly created, does it automatically create a submodel reference eithin the AAS, i.e. updating the AAS? -->
+
+**HTTP REST Example:**
+```REST
+PUT /shells/{aas-id-base64}/asset-information
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "assetKind": "Instance",
+  "globalAssetId": "new-asset-id"
+}
+```
 
 ## Submodel Events
 
@@ -253,23 +249,6 @@ _("*" indicates a mandatory parameter)_
 If present, the `data` property contains the full SM representation, including its semantic identification and all SM elements present at creation time. 
 This event MUST be triggered exactly once when a SM is first created and MUST NOT be triggered for subsequent changes to that SM. 
 The `dataschema` property can only reference the SM metamodel element.
-
-**HTTP REST Example:**
-```REST
-POST /submodels
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-
-Body:
-{
-  "id": "sm-id",
-  "idShort": "sm-id-short",
-  "submodelElements": []
-}
-
-```
 
 **The following interface operations will trigger this event:**
 
@@ -294,17 +273,9 @@ Body:
 
 _("*" indicates a mandatory parameter)_
 
-### Submodel Updated
-
-`io.admin-shell.events.v1.updated` — Triggered when the metadata of an existing SM changes. 
-This event concerns structural or descriptive changes at the SM level itself — such as changes to its semantic identification, administrative information, or kind — and is distinct from any changes to individual SME within it. 
-If present, the `data` property contains the updated SM representation. 
-Consumers SHOULD treat receipt of this event as an authoritative replacement for any previously held state of the shell identified by the same identifier. 
-The `dataschema` property can only reference the SM metamodel element as SMEs are handled elsewhere.
-
 **HTTP REST Example:**
 ```REST
-PUT /submodels/{sm-id-base64}
+POST /submodels
 
 Headers: 
 Accept: aaplication/json
@@ -313,11 +284,18 @@ Content-Type: application/json
 Body:
 {
   "id": "sm-id",
-  "idShort": "new-sm-id-short",
+  "idShort": "sm-id-short",
   "submodelElements": []
 }
-
 ```
+
+### Submodel Updated
+
+`io.admin-shell.events.v1.updated` — Triggered when the metadata of an existing SM changes. 
+This event concerns structural or descriptive changes at the SM level itself — such as changes to its semantic identification, administrative information, or kind — and is distinct from any changes to individual SME within it. 
+If present, the `data` property contains the updated SM representation. 
+Consumers SHOULD treat receipt of this event as an authoritative replacement for any previously held state of the shell identified by the same identifier. 
+The `dataschema` property can only reference the SM metamodel element as SMEs are handled elsewhere.
 
 **The following interface operations will trigger this event:**
 
@@ -353,20 +331,27 @@ _("*" indicates a mandatory parameter)_
 
 <!-- If a new SubmodelElement is created (PostSubmodelElement) or deleted (DeleteSubmodelElementByPath), does this update the Submodel itself? -->
 
+**HTTP REST Example:**
+```REST
+PUT /submodels/{sm-id-base64}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+{
+  "id": "sm-id",
+  "idShort": "new-sm-id-short",
+  "submodelElements": []
+}
+```
+
 ### Submodel Deleted
 
 `io.admin-shell.events.v1.deleted` — Triggered when a SM is permanently removed from the repository. 
 The AAS payload is absent; the identity of the deleted resource is conveyed through the `source` property in the envelope. 
 Consumers MUST consider any locally cached state for the identified SM invalid upon receipt of this event.
-
-**HTTP REST Example:**
-```REST
-DELETE /submodels/{sm-id-base64}
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-```
 
 **The following interface operations will trigger this event:**
 
@@ -390,6 +375,15 @@ Content-Type: application/json
 
 _("*" indicates a mandatory parameter)_
 
+**HTTP REST Example:**
+```REST
+DELETE /submodels/{sm-id-base64}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+```
+
 ## SubmodelElement Events
 
 ### SubmodelElement Created
@@ -398,23 +392,6 @@ _("*" indicates a mandatory parameter)_
 The source reference in the envelope identifies the containing element or Submodel into which the new element was inserted. 
 The `data` property contains the full representation of the newly created SME. 
 This event MUST be triggered exactly once per element creation.
-
-**HTTP REST Example:**
-```REST
-POST /submodels/{sm-id-base64}/submodelElements
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-
-Body:
-{
-  "idShort": "test-property",
-  "modelType": "Property",
-  "valueType": "xs:double",
-  "value": "25.0"
-}
-```
 
 **The following interface operations will trigger this event:**
 
@@ -448,24 +425,29 @@ Body:
 
 _("*" indicates a mandatory parameter)_
 
-### Value Changed
-
-`io.admin-shell.events.v1.valueChanged` — Triggered when the value of a DataElement changes while the element itself remains structurally unmodified. 
-If any other attribute changes, a SME Updated event is triggered. 
-If present, the `data` property contains the SME in its updated state. 
-Consumers SHOULD use this event as the primary mechanism for tracking live data updates in an AAS deployment.
-
 **HTTP REST Example:**
 ```REST
-PATCH /submodels/{sm-id-base64}/submodel-elements/{sme}/value
+POST /submodels/{sm-id-base64}/submodelElements
 
 Headers: 
 Accept: aaplication/json
 Content-Type: application/json
 
 Body:
-10.0
+{
+  "idShort": "test-property",
+  "modelType": "Property",
+  "valueType": "xs:double",
+  "value": "25.0"
+}
 ```
+
+### Value Changed
+
+`io.admin-shell.events.v1.valueChanged` — Triggered when the value of a DataElement changes while the element itself remains structurally unmodified. 
+If any other attribute changes, a SME Updated event is triggered. 
+If present, the `data` property contains the SME in its updated state. 
+Consumers SHOULD use this event as the primary mechanism for tracking live data updates in an AAS deployment.
 
 **The following interface operations will trigger this event:**
 
@@ -500,11 +482,36 @@ Body:
 
 _("*" indicates a mandatory parameter)_
 
+**HTTP REST Example:**
+```REST
+PATCH /submodels/{sm-id-base64}/submodel-elements/{sme}/value
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+
+Body:
+10.0
+```
+
 ### SubmodelElement Updated
 
 `io.admin-shell.events.v1.updated` — Triggered when the structure or metadata of an existing SME changes in a way other than a pure value change. 
 This includes changes to semantic identification, qualifiers, or category. 
 If present, the `data` property contains the updated element representation. Consumers SHOULD replace any previously held state of the identified element upon receipt.
+
+**The following interface operations will trigger this event:**
+
+- `PutSubmodelElementByPath`
+
+    Replaces an existing submodel element or creates a new submodel element at a specified path within the submodel element hierarchy
+
+    | Input Parameter | Output Parameter |
+    |----------|----------|
+    | Submodel element object*  | Status code*   |
+    | idShortPath via relative Reference/Keys to a submodel element which shall be replaced*  | New state of the submodel element |
+
+_("*" indicates a mandatory parameter)_
 
 **HTTP REST Example:**
 ```REST
@@ -523,34 +530,12 @@ Body:
 }
 ```
 
-**The following interface operations will trigger this event:**
-
-- `PutSubmodelElementByPath`
-
-    Replaces an existing submodel element or creates a new submodel element at a specified path within the submodel element hierarchy
-
-    | Input Parameter | Output Parameter |
-    |----------|----------|
-    | Submodel element object*  | Status code*   |
-    | idShortPath via relative Reference/Keys to a submodel element which shall be replaced*  | New state of the submodel element |
-
-_("*" indicates a mandatory parameter)_
-
 ### SubmodelElement Deleted
 
 `io.admin-shell.events.v1.deleted` — Triggered when a SME is removed from its containing Submodel, SubmodelElementList or SubmodelElementCollection. 
 The `source` property in the envelope identifies the deleted SME. 
 The SME payload is absent from the event. 
 Consumers MUST invalidate any locally cached state for the deleted element upon receipt.
-
-**HTTP REST Example:**
-```REST
-DELETE /submodels/{sm-id-base64}/submodel-elements/{sme}
-
-Headers: 
-Accept: aaplication/json
-Content-Type: application/json
-```
 
 **The following interface operations will trigger this event:**
 
@@ -571,6 +556,17 @@ Content-Type: application/json
     |----------|----------|
     | Submodel element object*  | Status code*   |
     | idShortPath via relative Reference/Keys to a submodel element which shall be replaced*  | New state of the submodel element |
+
+_("*" indicates a mandatory parameter)_
+
+**HTTP REST Example:**
+```REST
+DELETE /submodels/{sm-id-base64}/submodel-elements/{sme}
+
+Headers: 
+Accept: aaplication/json
+Content-Type: application/json
+```
 
 ### Operation Invoked
 


### PR DESCRIPTION
## WHAT

I added http REST examples as triggers to all of the Events. 

## WHY

For users to quickly be able to test events. 
Came out of discussion with Carlos: 
https://github.com/factory-x-contributions/async-aas-helm/pull/131 

## FURTHER NOTES

Might be able to make the http boxes a bit nicer. 