### PR TITLE
Fix failing git init container in deployment

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -75,6 +75,7 @@ jobs:
           # Remove <path:... directives
           sed -Ei 's/<path:factory-x-ci-cd\/data\/async-aas\#([a-zA-Z0-9-]+)>/\1/g' charts/async-aas-helm/values.yaml
           # Disable git init phase, we don't need initial model for testing the FA³ST deployment
+          sed -Ez 's/\n[[:space:]]*initialModelFile:[^\n]*//' -i charts/async-aas-helm/values.yaml
           sed -Ez 's/(initContainers:\s*\n[[:space:]]*-\s*name:\s*git\s*\n)[[:space:]]*enabled:\s*true/\1      enabled: false/' -i charts/async-aas-helm/values.yaml
           sed -Ez 's/(volumeMounts:\s*\n[[:space:]]*-\s*name:\s*seeding\s*\n)[[:space:]]*enabled:\s*true/\1      enabled: false/' -i charts/async-aas-helm/values.yaml
           sed -Ez 's/messageBus:\n( *)\"@class\": \"de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudevents\"/messageBus:\n\1\"@class\": \"de.fraunhofer.iosb.ilt.faaast.service.messagebus.internal.MessageBusInternal\"/' -i charts/async-aas-helm/values.yaml

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -140,10 +140,10 @@ faaast-service:
       args:
         - |
           https://<path:factory-x-ci-cd/data/async-aas#initial-aas-github-token>@github.com/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-location>
-          /app/resources/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-name>
+          /app/resources
       volumeMounts:
         - name: seeding
-          mountPath: /app/resources/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-name>
+          mountPath: /app/resources
 
   volumeMounts:
     - name: seeding

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -90,6 +90,8 @@ faaast-service:
     "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.mongo.PersistenceMongo"
     connectionString: "mongodb://<path:factory-x-ci-cd/data/async-aas#mongodb-admin-user>:<path:factory-x-ci-cd/data/async-aas#mongodb-admin-pw>@mongodb:27017"
     database: "faaast-service"
+    initialModelFile: /app/resources/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-name>
+    override: false
 
   endpoints:
     - "@class": "de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.HttpEndpoint"
@@ -138,9 +140,8 @@ faaast-service:
       image: alpine/git
       command: ["git", "clone"]
       args:
-        - |
-          https://<path:factory-x-ci-cd/data/async-aas#initial-aas-github-token>@github.com/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-location>
-          /app/resources
+        - "https://<path:factory-x-ci-cd/data/async-aas#initial-aas-github-token>@github.com/<path:factory-x-ci-cd/data/async-aas#initial-aas-file-location>"
+        - "/app/resources"
       volumeMounts:
         - name: seeding
           mountPath: /app/resources

--- a/charts/deploy.py
+++ b/charts/deploy.py
@@ -124,8 +124,8 @@ def run_helm(release: str, namespace: str | None, chart: str, values_file: str, 
         values_file,
         "--set",
         f"faaast-service.messageBus.host=tcp://{replacement_strategy('rabbitmq-broker-url', vault)[0]}-mqtt:1883,"
-        f"faaast-service.initContainers[0].enabled=false,"
-        f"faaast-service.volumeMounts[0].enabled=false,"
+        f"faaast-service.initContainers[0].enabled={'true'  if seeding else 'false'},"
+        f"faaast-service.volumeMounts[0].enabled={'true'  if seeding else 'false'},"
         f"faaast-service.endpoints[0].jwkProvider=http://{replacement_strategy('keycloak-url', vault)[0]}/realms/fa3st/protocol/openid-connect/certs"
     ]
     if namespace:
@@ -267,6 +267,7 @@ def cli_parser() -> argparse.ArgumentParser:
         "-s",
         "--seeding",
         required=False,
+        action="store_true",
         help="Use seeding for FA³ST Service (required vault fields: initial-aas-file-name, initial-aas-file-location, initial-aas-github-token)",
     )
     return parser


### PR DESCRIPTION
## WHAT

Trying to deploy the latest changes, FA³ST Service won't boot anymore. This is due to initContainer git-seeding not being able to download the initial AAS file (misconfiguration in the values.yaml). This PR fixes the seeding initContainer such that FA³ST can boot in the deployment again.

Also, in the deploy.py script, seeding is working properly now (-s does not require an argument anymore)

## WHY

Currently in a boot loop. This fell through in local testing due to seeding being disabled by default in deploy.py

## FURTHER NOTES

--