### PR TITLE
chore: update fa³st chart

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,10 +33,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.2"
+appVersion: "1.16.1"

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -3,7 +3,7 @@ name: umbrella-rabbitmq-aas
 description: A Helm chart for AAS deployment with RabbitMQ messaging
 dependencies:
   - name: faaast-service
-    version: 1.0.0
+    version: 1.0.1
     repository: "https://fraunhoferiosb.github.io/helm-charts-snapshot/"
   - name: faaast-registry
     version: 1.0.0
@@ -39,4 +39,4 @@ version: 0.7.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.1"
+appVersion: "1.16.2"


### PR DESCRIPTION
## WHAT

ArgoCD Vault Plugin allows to define paths to vault secrets in deployment configurations. These paths are resolved after helm template is executed. The current FA³ST chart's deployment.yaml does not allow this to work, modifying the path reference before it can be resolved by the plugin. It has since been updated (in the snapshot repository, version 1.0.1)

## WHY

Deployment fails due to wrong order of vault secret injection + string manipulation.

## FURTHER NOTES

See https://github.com/FraunhoferIOSB/FAAAST-Service/pull/1452 for FA³ST chart changes