### PR TITLE
fix: backend protocol to match actual

### DIFF
--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -122,7 +122,7 @@ faaast-service:
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-body-size: 150m
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     tls:
       - hosts:
           - "<path:factory-x-ci-cd/data/async-aas#faaast-service-url>"


### PR DESCRIPTION
## WHAT

the backend protocol of the FA³ST Service Ingress was defined as being "HTTPS". This is not true though, making the deployment fail. This PR will change HTTPS to HTTP.

## WHY

Deployment failing

## FURTHER NOTES

--