### PR TITLE
feat: persist fa³st registry and basyx env

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -45,7 +45,7 @@ jobs:
           check-latest: false
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -79,7 +79,20 @@ jobs:
           sed -Ez 's/(initContainers:\s*\n[[:space:]]*-\s*name:\s*git\s*\n)[[:space:]]*enabled:\s*true/\1      enabled: false/' -i charts/async-aas-helm/values.yaml
           sed -Ez 's/(volumeMounts:\s*\n[[:space:]]*-\s*name:\s*seeding\s*\n)[[:space:]]*enabled:\s*true/\1      enabled: false/' -i charts/async-aas-helm/values.yaml
           sed -Ez 's/messageBus:\n( *)\"@class\": \"de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudevents\"/messageBus:\n\1\"@class\": \"de.fraunhofer.iosb.ilt.faaast.service.messagebus.internal.MessageBusInternal\"/' -i charts/async-aas-helm/values.yaml
+          # Align basyx's MQTT client with the in-cluster rabbitmq broker (no external DNS / TLS in CI).
+          # Production uses wss://<broker-url>:443 via ingress; in CI we use the same WebSocket-MQTT path
+          # that the rabbitmq chart explicitly configures (web_mqtt.tcp.port = 9001, ws_path = /mqtt),
+          # just over plaintext ws and against the in-cluster service name. Auth: rabbitmq's auth_backends
+          # tries `internal` first, accepting the literal username/password strings that the placeholder
+          # substitution above leaves on both ends.
+          sed -i 's|^\(\s*\)mqtt\.hostname=.*$|\1mqtt.hostname=rabbitmq-mqtt|' charts/async-aas-helm/values.yaml
+          sed -i 's|^\(\s*\)mqtt\.protocol=.*$|\1mqtt.protocol=ws|' charts/async-aas-helm/values.yaml
+          sed -i 's|^\(\s*\)mqtt\.port=.*$|\1mqtt.port=443|' charts/async-aas-helm/values.yaml
+
+      - name: Create install namespace
+        run: kubectl create namespace async-aas-helm
+        if: steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts ./charts/async-aas-helm --helm-extra-args "--timeout 15m"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts ./charts/async-aas-helm --release-name async-aas-helm --namespace async-aas-helm --helm-extra-args "--timeout 5m"
         if: steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'

--- a/charts/async-aas-helm/Chart.yaml
+++ b/charts/async-aas-helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/async-aas-helm/templates/rabbitmq-mqtt-ingress.yaml
+++ b/charts/async-aas-helm/templates/rabbitmq-mqtt-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/websocket-services: {{ .Release.Name }}-rabbitmq-mqtt
+    nginx.ingress.kubernetes.io/websocket-services: rabbitmq-mqtt
     kubernetes.io/tls-acme: "true"
 spec:
   ingressClassName: nginx
@@ -29,7 +29,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .Release.Name }}-rabbitmq-mqtt
+                name: rabbitmq-mqtt
                 port:
                   number: 443
 {{- end }}

--- a/charts/async-aas-helm/templates/rabbitmq-mqtt-service.yaml
+++ b/charts/async-aas-helm/templates/rabbitmq-mqtt-service.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.rabbitmq.ingress.certManager.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-rabbitmq-mqtt
+  name: rabbitmq-mqtt
   labels:
     app.kubernetes.io/name: rabbitmq-mqtt
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -16,4 +15,3 @@ spec:
   selector:
     app.kubernetes.io/name: rabbitmq
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}

--- a/charts/async-aas-helm/values.yaml
+++ b/charts/async-aas-helm/values.yaml
@@ -31,14 +31,18 @@ faaast-registry:
       orm: "orm.xml"
       # the following enables logging of the SQL statements that JPA (Hibernate) executes
       showSql: false
+      properties:
+        hibernate:
+          formatSql: ""
+          dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate:
         ddlAuto: "update"
         openInView: true
     datasource:
-      driver: "org.h2.Driver"
-      url: "jdbc:h2:mem:testdb"
-      username: "sa"
-      password: ""
+      driver: org.postgresql.Driver
+      url: jdbc:postgresql://postgresql:5432/fa3st-registry
+      username: <path:factory-x-ci-cd/data/async-aas#kc-pg-user>
+      password: <path:factory-x-ci-cd/data/async-aas#kc-pg-pw>
 
   ingress:
     enabled: true
@@ -69,11 +73,6 @@ faaast-service:
     repository: ghcr.io/factory-x-contributions/fa3st-service
     tag: 0.2.0
     pullPolicy: Always
-
-  debug:
-    enabled: false
-    port: 5555
-    suspendOnStart: true
 
   core:
     aasRegistries:
@@ -168,12 +167,21 @@ aas-basyx-v2-full:
     enabled: true
     postgresql:
       enabled: true
+      fullnameOverride: postgresql
       image:
         repository: "bitnamilegacy/postgresql"
       auth:
         username: <path:factory-x-ci-cd/data/async-aas#kc-pg-user>
         password: <path:factory-x-ci-cd/data/async-aas#kc-pg-pw>
         database: <path:factory-x-ci-cd/data/async-aas#kc-pg-db>
+      primary:
+        initdb:
+          # Runs only on first init (empty data dir). To re-trigger on an
+          # existing cluster, delete the PVC: data-postgresql-0
+          scripts:
+            10-create-fa3st-registry-db.sql: |
+              CREATE DATABASE "fa3st-registry";
+              GRANT ALL PRIVILEGES ON DATABASE "fa3st-registry" TO "<path:factory-x-ci-cd/data/async-aas#kc-pg-user>";
     ingress:
       enabled: true
       ingressClassName: "nginx"
@@ -230,7 +238,7 @@ aas-basyx-v2-full:
     config: |-
       server.port=8081
 
-      basyx.backend = InMemory
+      basyx.backend=MongoDB
 
       #basyx.environment=file:aas
 
@@ -263,6 +271,7 @@ aas-basyx-v2-full:
       spring.data.mongodb.uri=mongodb://mongodb
       spring.data.mongodb.port=27017
       spring.data.mongodb.database=factoryx-mongo-db
+      spring.data.mongodb.authentication-database=<path:factory-x-ci-cd/data/async-aas#mongodb-auth-source>
       spring.data.mongodb.username=<path:factory-x-ci-cd/data/async-aas#mongodb-admin-user>
       spring.data.mongodb.password=<path:factory-x-ci-cd/data/async-aas#mongodb-admin-pw>
 


### PR DESCRIPTION
- fa³st registry: switch from in-memory H2 to the bundled PostgreSQL.
- Add Postgres initdb script creating the `fa3st-registry` database (Postgres needs the DB up front).
- basyx env: set `spring.data.mongodb.authentication-database`.