### PR TITLE
docs(specs): add mermaid sequence diagram for source=Referable flow

### DIFF
--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -86,5 +86,17 @@
 <p id="readme">
 <!-- README_CONTENT -->
 </p>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false });
+  // marked renders ```mermaid fences as <pre><code class="language-mermaid">…</code></pre>;
+  // rewrite to the <pre class="mermaid">…</pre> shape mermaid.run() expects.
+  document.querySelectorAll('pre > code.language-mermaid').forEach((code) => {
+    const pre = code.parentElement;
+    pre.className = 'mermaid';
+    pre.textContent = code.textContent;
+  });
+  mermaid.run();
+</script>
 </body>
 </html>

--- a/.github/resources/index.html
+++ b/.github/resources/index.html
@@ -70,6 +70,21 @@
     .button:hover {
       background-color: #333;
     }
+
+    #readme table {
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+
+    #readme table th,
+    #readme table td {
+      border: 1px solid #ddd;
+      padding: 0.4rem 0.75rem;
+    }
+
+    #readme table th {
+      background-color: #f6f6f6;
+    }
   </style>
 
 </head>
@@ -83,9 +98,9 @@
 <p>
   <a href="./submodel-repository-submodelelement/" class="button"><b>SubmodelElement-level</b> Events emitted by <b>Submodel Repositories</b></a>
 </p>
-<p id="readme">
+<div id="readme">
 <!-- README_CONTENT -->
-</p>
+</div>
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
   mermaid.initialize({ startOnLoad: false });

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,11 @@ jobs:
       - name: Inject README into frontpage
         run: |
           README_HTML=$(npx --yes marked specs/README.md | sed 's|./artifacts/|./specs/artifacts/|g')
+          # Escape sed replacement metacharacters (\, &, |) before splicing,
+          # else `&` reinjects the matched delimiter — corrupting `&gt;`, `&#39;`, etc.
+          README_HTML="${README_HTML//\\/\\\\}"
+          README_HTML="${README_HTML//&/\\&}"
+          README_HTML="${README_HTML//|/\\|}"
           README_HTML="${README_HTML//$'\n'/\\n}"
           sed -i "s|<!-- README_CONTENT -->|$README_HTML|" index.html
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,18 +10,33 @@ Specifically, it ensures that data consumers are immediately informed of any cha
 
 ![MQTT Concept](./artifacts/aas-sync-mqtt-concept.svg)
 
-### Flow: event with `Referable` in `source`
+### Flow: slim event with `Referable` in `source`
 
-When the server places the `Referable` directly as the event's `source`, the
-consumer fetches the data in a single round-trip — no event-element
+For slim events — where the envelope carries only the `Referable` reference
+in `source` and no payload — the consumer fetches the data in a single
+round-trip, then isolates the ex post state locally. No event-element
 indirection, no diff query.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    Server->>Client: cloud event with Referable in source
+    Server->>Client: cloud event
     Client->>Server: GET event.source
     Server-->>Client: data
+    Client->>Client: isolate ex post state
+```
+
+### Flow: fat event with payload in `data`
+
+For fat events — where the server inlines the full `Referable` payload in
+the event's `data` property — the consumer isolates the ex post state
+directly from the event. No follow-up fetch required.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Server->>Client: cloud event
+    Client->>Client: isolate ex post state
 ```
 
 ### Normative Disclaimer 

--- a/specs/README.md
+++ b/specs/README.md
@@ -166,7 +166,7 @@ _("*" indicates a mandatory parameter)_
 POST /shells
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -260,7 +260,7 @@ _("*" indicates a mandatory parameter)_
 PUT /shells/{aas-id-base64}/asset-information
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -307,7 +307,7 @@ _("*" indicates a mandatory parameter)_
 POST /submodels
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -365,7 +365,7 @@ _("*" indicates a mandatory parameter)_
 PUT /submodels/{sm-id-base64}
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -409,7 +409,7 @@ _("*" indicates a mandatory parameter)_
 DELETE /submodels/{sm-id-base64}
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 ```
 
@@ -459,7 +459,7 @@ _("*" indicates a mandatory parameter)_
 POST /submodels/{sm-id-base64}/submodelElements
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -516,7 +516,7 @@ _("*" indicates a mandatory parameter)_
 PATCH /submodels/{sm-id-base64}/submodel-elements/{sme}/value
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body:
@@ -547,7 +547,7 @@ _("*" indicates a mandatory parameter)_
 PUT /submodels/{sm-id-base64}/submodel-elements/{sme}
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 
 Body: 
@@ -593,7 +593,7 @@ _("*" indicates a mandatory parameter)_
 DELETE /submodels/{sm-id-base64}/submodel-elements/{sme}
 
 Headers: 
-Accept: aaplication/json
+Accept: application/json
 Content-Type: application/json
 ```
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -178,7 +178,7 @@ The `dataschema` property can only reference elements with their own HTTP endpoi
 - `PutAssetAdministrationShell` 
 *(in case an AAS with the ID specified in the payload is not existing yet)*
 
-    Creates or replaces an existing Asset Administration Shell Descriptor, i.e., replaces registration information
+    Creates or replaces an existing Asset Administration Shell, i.e. replaces registration information
 
     | Input Parameter | Output Parameter |
     |----------|----------|

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,6 +10,20 @@ Specifically, it ensures that data consumers are immediately informed of any cha
 
 ![MQTT Concept](./artifacts/aas-sync-mqtt-concept.svg)
 
+### Flow: event with `Referable` in `source`
+
+When the server places the `Referable` directly as the event's `source`, the
+consumer fetches the data in a single round-trip — no event-element
+indirection, no diff query.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Server->>Client: cloud event with Referable in source
+    Client->>Server: GET event.source
+    Server-->>Client: data
+```
+
 ### Normative Disclaimer 
 The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in this document are to be interpreted as described in RFC 2119.
 


### PR DESCRIPTION
- Adds a mermaid sequence diagram to `specs/README.md` for the direct `source=Referable` event flow.
- Loads `mermaid@11` from jsdelivr in the Pages frontpage so the fence renders as SVG.

preview: https://arnoweiss.github.io/async-aas-helm/

Closes #143